### PR TITLE
Improving performance

### DIFF
--- a/psx-core/src/cdrom.rs
+++ b/psx-core/src/cdrom.rs
@@ -179,11 +179,7 @@ impl Cdrom {
 
 // clocking and commands
 impl Cdrom {
-    pub fn clock(&mut self, interrupt_requester: &mut impl InterruptRequester) {
-        self.execute_next_command(interrupt_requester);
-    }
-
-    fn execute_next_command(&mut self, interrupt_requester: &mut impl InterruptRequester) {
+    pub fn clock(&mut self, interrupt_requester: &mut impl InterruptRequester, cycles: u32) {
         if self.interrupt_flag & 7 != 0 {
             // pending interrupts, waiting for acknowledgement
             return;
@@ -191,10 +187,11 @@ impl Cdrom {
         if let Some(cmd) = self.command {
             // delay (this applies for all parts of the command)
             // If no delay is needed, it can be reset from the command itself
-            if self.command_delay_timer > 0 {
-                self.command_delay_timer -= 1;
+            if self.command_delay_timer > cycles + 1 {
+                self.command_delay_timer -= cycles;
                 return;
             }
+
             // reset the timer here, so that if a command needs to change the value
             // it can do so
             self.command_delay_timer = CDROM_COMMAND_DEFAULT_DELAY;

--- a/psx-core/src/cpu.rs
+++ b/psx-core/src/cpu.rs
@@ -58,14 +58,14 @@ impl Cpu {
             if let Some(instruction) = self.bus_read_u32(bus, self.regs.pc) {
                 let instruction = Instruction::from_u32(instruction);
 
-                self.regs.pc += 4;
-
                 if let Some(jump_dest) = self.jump_dest_next.take() {
                     log::trace!("pc jump {:08X}", jump_dest);
                     self.regs.pc = jump_dest;
                 }
 
                 log::trace!("{:08X}: {:02X?}", self.regs.pc, instruction);
+
+                self.regs.pc += 4;
                 self.execute_instruction(&instruction, bus);
 
                 // exit so that we can run dma

--- a/psx-core/src/cpu.rs
+++ b/psx-core/src/cpu.rs
@@ -32,6 +32,8 @@ pub struct Cpu {
     cop2: Gte,
 
     jump_dest_next: Option<u32>,
+
+    elapsed_cycles: u32,
 }
 
 impl Cpu {
@@ -42,6 +44,8 @@ impl Cpu {
             cop0: SystemControlCoprocessor::default(),
             cop2: Gte::default(),
             jump_dest_next: None,
+
+            elapsed_cycles: 0,
         }
     }
 
@@ -69,6 +73,11 @@ impl Cpu {
                 self.execute_instruction(instruction, bus);
             }
         }
+    }
+
+    #[inline]
+    pub fn take_elapsed_cycles(&mut self) -> u32 {
+        std::mem::take(&mut self.elapsed_cycles)
     }
 }
 
@@ -649,6 +658,8 @@ impl Cpu {
 
 impl Cpu {
     fn bus_read_u32<P: BusLine>(&mut self, bus: &mut P, addr: u32) -> Option<u32> {
+        self.elapsed_cycles += 1;
+
         if addr % 4 != 0 {
             self.execute_exception(Exception::AddressErrorLoad);
             self.cop0.write_bad_vaddr(addr);
@@ -663,6 +674,8 @@ impl Cpu {
     }
 
     fn bus_write_u32<P: BusLine>(&mut self, bus: &mut P, addr: u32, data: u32) {
+        self.elapsed_cycles += 1;
+
         if addr % 4 != 0 {
             self.execute_exception(Exception::AddressErrorStore);
             self.cop0.write_bad_vaddr(addr);

--- a/psx-core/src/cpu/instruction.rs
+++ b/psx-core/src/cpu/instruction.rs
@@ -103,7 +103,7 @@ pub enum Opcode {
     Swc(u8),
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 pub struct Instruction {
     pub opcode: Opcode,
 

--- a/psx-core/src/gpu/gpu_context.rs
+++ b/psx-core/src/gpu/gpu_context.rs
@@ -9,7 +9,7 @@ use vulkano::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::{Device, Queue};
 use vulkano::format::{ClearValue, Format};
 use vulkano::image::view::{ComponentMapping, ComponentSwizzle, ImageView};
-use vulkano::image::{ImageDimensions, StorageImage};
+use vulkano::image::{ImageCreateFlags, ImageDimensions, ImageUsage, StorageImage};
 use vulkano::pipeline::graphics::input_assembly::{InputAssemblyState, PrimitiveTopology};
 use vulkano::pipeline::graphics::vertex_input::BuffersDefinition;
 use vulkano::pipeline::graphics::viewport::{Viewport, ViewportState};
@@ -215,7 +215,7 @@ impl GpuContext {
         gpu_read_sender: Sender<u32>,
         gpu_front_image_sender: Sender<Arc<StorageImage>>,
     ) -> Self {
-        let render_image = StorageImage::new(
+        let render_image = StorageImage::with_usage(
             device.clone(),
             ImageDimensions::Dim2d {
                 width: 1024,
@@ -223,11 +223,19 @@ impl GpuContext {
                 array_layers: 1,
             },
             Format::A1R5G5B5_UNORM_PACK16,
+            ImageUsage {
+                transfer_source: true,
+                transfer_destination: true,
+                color_attachment: true,
+                sampled: true,
+                ..ImageUsage::none()
+            },
+            ImageCreateFlags::none(),
             [queue.family()],
         )
         .unwrap();
 
-        let render_image_back_image = StorageImage::new(
+        let render_image_back_image = StorageImage::with_usage(
             device.clone(),
             ImageDimensions::Dim2d {
                 width: 1024,
@@ -235,6 +243,12 @@ impl GpuContext {
                 array_layers: 1,
             },
             Format::A1R5G5B5_UNORM_PACK16,
+            ImageUsage {
+                transfer_destination: true,
+                sampled: true,
+                ..ImageUsage::none()
+            },
+            ImageCreateFlags::none(),
             [queue.family()],
         )
         .unwrap();
@@ -844,7 +858,7 @@ impl GpuContext {
             )
         };
 
-        let front_image = StorageImage::new(
+        let front_image = StorageImage::with_usage(
             self.device.clone(),
             ImageDimensions::Dim2d {
                 width: size[0],
@@ -852,6 +866,12 @@ impl GpuContext {
                 array_layers: 1,
             },
             Format::B8G8R8A8_UNORM,
+            ImageUsage {
+                transfer_source: true,
+                color_attachment: true,
+                ..ImageUsage::none()
+            },
+            ImageCreateFlags::none(),
             Some(self.queue.family()),
         )
         .unwrap();

--- a/psx-core/src/lib.rs
+++ b/psx-core/src/lib.rs
@@ -46,7 +46,13 @@ impl Psx {
     /// return `true` on the beginning of VBLANK
     pub fn clock(&mut self) -> bool {
         let in_vblank_old = self.bus.gpu().in_vblank();
-        self.cpu.execute_next(&mut self.bus);
+
+        // this number doesn't mean anything
+        // TODO: research on when to stop the CPU (maybe fixed number? block of code? other?)
+        for _ in 0..32 {
+            self.cpu.execute_next(&mut self.bus);
+        }
+        self.bus.clock_components(self.cpu.take_elapsed_cycles());
 
         self.bus.gpu().in_vblank() && !in_vblank_old
     }

--- a/psx-core/src/lib.rs
+++ b/psx-core/src/lib.rs
@@ -49,9 +49,8 @@ impl Psx {
 
         // this number doesn't mean anything
         // TODO: research on when to stop the CPU (maybe fixed number? block of code? other?)
-        for _ in 0..32 {
-            self.cpu.execute_next(&mut self.bus);
-        }
+        self.cpu.clock(&mut self.bus, 32);
+
         self.bus.clock_components(self.cpu.take_elapsed_cycles());
 
         self.bus.gpu().in_vblank() && !in_vblank_old

--- a/psx-core/src/memory.rs
+++ b/psx-core/src/memory.rs
@@ -298,11 +298,8 @@ impl CpuBus {
     }
 
     pub fn clock_components(&mut self, cpu_cycles: u32) {
-        for _ in 0..cpu_cycles {
-            // TODO: handle Cpu timing better (this should clock for at least once
-            //  for every instruction)
-            self.dma.clock_dma(&mut self.dma_bus, &mut self.interrupts);
-        }
+        self.dma
+            .clock_dma(&mut self.dma_bus, &mut self.interrupts, cpu_cycles);
 
         // almost 2 GPU clocks per 1 CPU
         let (dot_clocks, hblank_clock) =


### PR DESCRIPTION
Fixes #4 

To improve performance, I reduced the number of times, `clock_components` in the `Bus` is called, i.e. we perform computation at one go (for example incrementing the `dot` counter in the `GPU` by `cpu_cycles * 2` each time and not just by `1`).

Also, correcting the DMA timing will improve the performance, since we were performing whole blocks of DMA transfer during only `1` `cpu_cycle` which is not really accurate, nor good.
The DMA now is executed as if it were CPU, meaning that the cycles produced by the DMA component will be used to clock the other components.

Also changed the usage of images used in the `gpu`, it doesn't change much, but being specific with images is always good.