### PR TITLE
Added debugger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf2eec61efe56aa1e813f5126959296933cf0700030e4314786c48779a66ab82"
 dependencies = [
  "log",
- "nix",
+ "nix 0.22.3",
 ]
 
 [[package]]
@@ -146,6 +146,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ab1b92798304eedc095b53942963240037c0516452cb11aeba709d420b2219"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi",
 ]
 
 [[package]]
@@ -428,6 +439,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
+name = "fd-lock"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11dcc7e4d79a8c89b9ab4c6f5c30b1fc4a83c420792da3542fd31179ed5f517"
+dependencies = [
+ "cfg-if 1.0.0",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +557,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+
+[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +604,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "winapi",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -695,6 +760,17 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "libc",
 ]
 
 [[package]]
@@ -883,6 +959,7 @@ dependencies = [
  "byteorder",
  "crossbeam",
  "log",
+ "rustyline",
  "vulkano",
  "vulkano-shaders",
 ]
@@ -930,6 +1007,41 @@ name = "regex-syntax"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+
+[[package]]
+name = "rustix"
+version = "0.35.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c825b8aa8010eb9ee99b75f05e10180b9278d161583034d7574c9d617aeada"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustyline"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1cd5ae51d3f7bf65d7969d579d502168ef578f289452bd8ccc91de28fda20e"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "clipboard-win",
+ "fd-lock",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.24.2",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
 
 [[package]]
 name = "ryu"
@@ -1028,12 +1140,18 @@ dependencies = [
  "lazy_static",
  "log",
  "memmap2",
- "nix",
+ "nix 0.22.3",
  "pkg-config",
  "wayland-client",
  "wayland-cursor",
  "wayland-protocols",
 ]
+
+[[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strsim"
@@ -1101,6 +1219,24 @@ name = "unicode-ident"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
 name = "version_check"
@@ -1238,7 +1374,7 @@ dependencies = [
  "bitflags",
  "downcast-rs",
  "libc",
- "nix",
+ "nix 0.22.3",
  "scoped-tls",
  "wayland-commons",
  "wayland-scanner",
@@ -1251,7 +1387,7 @@ version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f6e5e340d7c13490eca867898c4cec5af56c27a5ffe5c80c6fc4708e22d33e"
 dependencies = [
- "nix",
+ "nix 0.22.3",
  "once_cell",
  "smallvec",
  "wayland-sys",
@@ -1263,7 +1399,7 @@ version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c52758f13d5e7861fc83d942d3d99bf270c83269575e52ac29e5b73cb956a6bd"
 dependencies = [
- "nix",
+ "nix 0.22.3",
  "wayland-client",
  "xcursor",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,6 +890,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "phf"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +1001,7 @@ dependencies = [
  "byteorder",
  "crossbeam",
  "log",
+ "phf",
  "rustyline",
  "vulkano",
  "vulkano-shaders",
@@ -972,6 +1015,21 @@ checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 
 [[package]]
 name = "raw-window-handle"
@@ -1121,6 +1179,12 @@ dependencies = [
  "lazy_static",
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Amjad Alsharafi <amjadsharafi10@gmail.com>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["debugger"]
+debugger = ["psx-core/debugger"]
 
 [dependencies]
 psx-core = { path = "./psx-core", version = "*" }

--- a/psx-core/Cargo.toml
+++ b/psx-core/Cargo.toml
@@ -16,3 +16,4 @@ vulkano-shaders = "0.29"
 bytemuck = { version = "1.9.1", features = ["derive"] }
 
 crossbeam = "0.8.1"
+rustyline = { version = "10.0.0", default-features = false }

--- a/psx-core/Cargo.toml
+++ b/psx-core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-debugger = ["dep:rustyline"]
+debugger = ["dep:rustyline", "dep:phf"]
 
 [dependencies]
 byteorder = "1.4.2"
@@ -20,3 +20,4 @@ bytemuck = { version = "1.9.1", features = ["derive"] }
 
 crossbeam = "0.8.1"
 rustyline = { version = "10.0.0", default-features = false, optional = true }
+phf = { version = "0.11.1", default-features = false, optional = true, features = ["macros"] }

--- a/psx-core/Cargo.toml
+++ b/psx-core/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+debugger = ["dep:rustyline"]
+
 [dependencies]
 byteorder = "1.4.2"
 log = "0.4.14"
@@ -16,4 +19,4 @@ vulkano-shaders = "0.29"
 bytemuck = { version = "1.9.1", features = ["derive"] }
 
 crossbeam = "0.8.1"
-rustyline = { version = "10.0.0", default-features = false }
+rustyline = { version = "10.0.0", default-features = false, optional = true }

--- a/psx-core/src/cpu.rs
+++ b/psx-core/src/cpu.rs
@@ -131,7 +131,7 @@ impl Cpu {
 
                 // breakpoint hit
                 if self.debugger.trace_instruction(
-                    self.regs.pc,
+                    &self.regs,
                     self.jump_dest_next.is_some(),
                     &instruction,
                 ) {

--- a/psx-core/src/cpu.rs
+++ b/psx-core/src/cpu.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "debugger")]
 mod debugger;
 mod instruction;
 mod instruction_format;
@@ -10,7 +11,45 @@ use crate::memory::BusLine;
 use instruction::{Instruction, Opcode};
 use register::Registers;
 
+#[cfg(feature = "debugger")]
 use self::debugger::Debugger;
+
+#[cfg(not(feature = "debugger"))]
+struct Debugger;
+
+#[cfg(not(feature = "debugger"))]
+// dummy implementation when the debugger is disabled
+impl Debugger {
+    #[inline]
+    pub fn new() -> Self {
+        Self
+    }
+
+    #[inline]
+    pub fn set_pause(&mut self, _pause: bool) {}
+
+    #[inline]
+    pub fn paused(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    pub fn handle<P: CpuBusProvider>(&mut self, _regs: &Registers, _bus: &mut P) -> bool {
+        false
+    }
+
+    #[inline]
+    pub fn trace_instruction(
+        &mut self,
+        _pc: u32,
+        _jumping: bool,
+        _instruction: &Instruction,
+    ) -> bool {
+        false
+    }
+
+    pub fn trace_write(&mut self, _addr: u32) {}
+}
 
 pub trait CpuBusProvider: BusLine {
     fn pending_interrupts(&self) -> bool;
@@ -62,6 +101,7 @@ impl Cpu {
         self.debugger.set_pause(paused);
     }
 
+    #[cfg(feature = "debugger")]
     pub fn print_cpu_registers(&self) {
         self.regs.debug_print();
     }

--- a/psx-core/src/cpu.rs
+++ b/psx-core/src/cpu.rs
@@ -116,7 +116,7 @@ impl Cpu {
 
         for _ in 0..clocks {
             if let Some(instruction) = self.bus_read_u32(bus, self.regs.pc) {
-                let instruction = Instruction::from_u32(instruction);
+                let instruction = Instruction::from_u32(instruction, self.regs.pc);
 
                 log::trace!(
                     "{:08X}: {}{}",

--- a/psx-core/src/cpu.rs
+++ b/psx-core/src/cpu.rs
@@ -1,42 +1,16 @@
+mod debugger;
 mod instruction;
 mod instruction_format;
 mod instructions_table;
 mod register;
 
-use std::collections::HashSet;
-use std::io::Write;
-use std::{process, thread};
-
 use crate::coprocessor::{Gte, SystemControlCoprocessor};
 use crate::memory::BusLine;
 
-use crossbeam::channel::{Receiver, Sender};
 use instruction::{Instruction, Opcode};
 use register::Registers;
-use rustyline::error::ReadlineError;
-use rustyline::{Config, Editor};
 
-use self::instruction_format::{GENERAL_REG_NAMES, REG_HI_NAME, REG_LO_NAME, REG_PC_NAME};
-use self::register::Register;
-
-/// Instructing the editor thread on what to do.
-///
-/// The reason for this, is that the `Editor` object transforms the terminal
-/// to raw mode, and thus if its created, we can't Ctrl-C to kill the emulator.
-/// For better user experience, we create the editor only when needed.
-enum EditorCmd {
-    /// Create a new editor and read input
-    Start,
-    /// Continue reading input
-    Continue,
-    /// Stop reading input and destroy the editor
-    Stop,
-}
-
-fn create_editor() -> Editor<()> {
-    let conf = Config::builder().auto_add_history(true).build();
-    Editor::with_config(conf).unwrap()
-}
+use self::debugger::Debugger;
 
 pub trait CpuBusProvider: BusLine {
     fn pending_interrupts(&self) -> bool;
@@ -66,49 +40,11 @@ pub struct Cpu {
 
     elapsed_cycles: u32,
 
-    instruction_trace: bool,
-    paused: bool,
-    instruction_breakpoints: HashSet<u32>,
-    write_breakpoints: HashSet<u32>,
-    // currently on top of breakpoint, so ignore it and continue when unpaused
-    // so that we don't get stuck in one instruction.
-    in_breakpoint: bool,
-    // allow to execute one instruction only
-    step: bool,
-    stdin_rx: Receiver<String>,
-    editor_tx: Sender<EditorCmd>,
+    debugger: Debugger,
 }
 
 impl Cpu {
     pub fn new() -> Self {
-        let (stdin_tx, stdin_rx) = crossbeam::channel::bounded(1);
-        let (editor_tx, editor_rx) = crossbeam::channel::bounded(1);
-
-        thread::spawn(move || {
-            let mut editor = None;
-
-            loop {
-                if let Ok(cmd) = editor_rx.recv() {
-                    match cmd {
-                        EditorCmd::Start => editor = Some(create_editor()),
-                        EditorCmd::Continue => {
-                            assert!(editor.is_some());
-                        }
-                        EditorCmd::Stop => continue,
-                    }
-                    // flush all outputs
-                    std::io::stdout().flush().unwrap();
-                    match editor.as_mut().unwrap().readline("CPU> ") {
-                        Ok(line) => {
-                            stdin_tx.send(line).unwrap();
-                        }
-                        Err(ReadlineError::Interrupted) => process::exit(0),
-                        _ => {}
-                    }
-                }
-            }
-        });
-
         Self {
             // reset value
             regs: Registers::new(),
@@ -118,57 +54,12 @@ impl Cpu {
 
             elapsed_cycles: 0,
 
-            instruction_trace: false,
-            paused: false,
-            instruction_breakpoints: HashSet::new(),
-            write_breakpoints: HashSet::new(),
-            in_breakpoint: false,
-            step: false,
-            stdin_rx,
-            editor_tx,
+            debugger: Debugger::new(),
         }
     }
 
-    pub fn set_instruction_trace(&mut self, trace: bool) {
-        self.instruction_trace = trace;
-        println!("Instruction trace: {}", self.instruction_trace);
-    }
-
-    /// Pause the CPU and instructs the editor thread to start reading commands.
-    /// Note: make sure you call this function after printing all the output you
-    /// need, otherwise the editor thread might print the prompt in between your prints.
-    pub fn set_pause(&mut self, pause: bool) {
-        // only send command to editor thread
-        // if we are actually changing the state
-        if self.paused ^ pause {
-            if pause {
-                self.editor_tx.send(EditorCmd::Start).ok();
-            } else {
-                self.editor_tx.send(EditorCmd::Stop).ok();
-            }
-        }
-
-        self.paused = pause;
-    }
-
-    pub fn add_breakpoint(&mut self, address: u32) {
-        self.instruction_breakpoints.insert(address);
-        println!("Breakpoint added: 0x{:08X}", address);
-    }
-
-    pub fn remove_breakpoint(&mut self, address: u32) {
-        self.instruction_breakpoints.remove(&address);
-        println!("Breakpoint removed: 0x{:08X}", address);
-    }
-
-    pub fn add_write_breakpoint(&mut self, address: u32) {
-        self.write_breakpoints.insert(address);
-        println!("Write Breakpoint added: 0x{:08X}", address);
-    }
-
-    pub fn remove_write_breakpoint(&mut self, address: u32) {
-        self.write_breakpoints.remove(&address);
-        println!("Write Breakpoint removed: 0x{:08X}", address);
+    pub fn set_pause(&mut self, paused: bool) {
+        self.debugger.set_pause(paused);
     }
 
     pub fn print_cpu_registers(&self) {
@@ -176,170 +67,7 @@ impl Cpu {
     }
 
     pub fn clock<P: CpuBusProvider>(&mut self, bus: &mut P, clocks: u32) -> u32 {
-        if self.paused {
-            if let Ok(cmd) = self.stdin_rx.try_recv() {
-                let mut tokens = cmd.trim().split_whitespace();
-                let mut cmd = tokens.next();
-                let modifier = cmd.and_then(|c| {
-                    c.split_once('/').map(|(s1, s2)| {
-                        cmd = Some(s1);
-                        s2
-                    })
-                });
-                let addr = tokens.next().and_then(|a| {
-                    if a.starts_with('$') {
-                        let register_name = &a[1..];
-                        let register = GENERAL_REG_NAMES
-                            .iter()
-                            .position(|&r| r == register_name)
-                            .map(|i| Register::from_byte(i as u8));
-                        match register {
-                            Some(r) => Some(self.regs.read_register(r)),
-                            None => match register_name {
-                                REG_PC_NAME => Some(self.regs.pc),
-                                REG_HI_NAME => Some(self.regs.hi),
-                                REG_LO_NAME => Some(self.regs.lo),
-                                _ => {
-                                    println!("Invalid register name: {}", register_name);
-                                    None
-                                }
-                            },
-                        }
-                    } else {
-                        let value = u32::from_str_radix(a.trim_start_matches("0x"), 16);
-                        match value {
-                            Ok(value) => Some(value),
-                            Err(_) => {
-                                println!("Invalid address: {}", a);
-                                None
-                            }
-                        }
-                    }
-                });
-
-                match cmd {
-                    Some("h") => {
-                        println!("h - help");
-                        println!("r - print registers");
-                        println!("c - continue");
-                        println!("s - step");
-                        println!("tt - enable trace");
-                        println!("tf - disbale trace");
-                        println!("stack [0xn] - print stack [n entries in hex]");
-                        println!("b <addr> - set breakpoint");
-                        println!("rb <addr> - remove breakpoint");
-                        println!("wb <addr> - set write breakpoint");
-                        println!("wrb <addr> - remove write breakpoint");
-                        println!("lb - list breakpoints");
-                        println!("m[32/16/8] <addr> - print content of memory (default u32)");
-                        println!("p <addr>/<$reg> - print address or register value");
-                    }
-                    Some("r") => self.print_cpu_registers(),
-                    Some("c") => self.set_pause(false),
-                    Some("s") => {
-                        self.set_pause(false);
-                        self.step = true;
-                    }
-                    Some("tt") => self.set_instruction_trace(true),
-                    Some("tf") => self.set_instruction_trace(false),
-                    Some("stack") => {
-                        let n = addr.unwrap_or(10);
-                        let sp = self.regs.read_register(register::RegisterType::Sp.into());
-                        println!("Stack: SP=0x{:08X}", sp);
-                        for i in 0..n {
-                            println!("    {:08X}", bus.read_u32(sp + i * 4));
-                        }
-                    }
-                    Some("b") => {
-                        if let Some(addr) = addr {
-                            self.add_breakpoint(addr);
-                        } else {
-                            println!("Usage: b <address>");
-                        }
-                    }
-                    Some("rb") => {
-                        if let Some(addr) = addr {
-                            self.remove_breakpoint(addr);
-                        } else {
-                            println!("Usage: rb <address>");
-                        }
-                    }
-                    Some("wb") => {
-                        if let Some(addr) = addr {
-                            self.add_write_breakpoint(addr);
-                        } else {
-                            println!("Usage: wb <address>");
-                        }
-                    }
-                    Some("wrb") => {
-                        if let Some(addr) = addr {
-                            self.remove_write_breakpoint(addr);
-                        } else {
-                            println!("Usage: wrb <address>");
-                        }
-                    }
-                    Some("lb") => {
-                        for bp in self.instruction_breakpoints.iter() {
-                            println!("Breakpoint: 0x{:08X}", bp);
-                        }
-                        for bp in self.write_breakpoints.iter() {
-                            println!("Write Breakpoint: 0x{:08X}", bp);
-                        }
-                    }
-                    Some("m") | Some("m32") => {
-                        let count = modifier.and_then(|m| m.parse::<u32>().ok()).unwrap_or(1);
-                        if let Some(addr) = addr {
-                            for i in 0..count {
-                                let addr = addr + i * 4;
-                                let val = bus.read_u32(addr);
-                                println!("[0x{:08X}] = 0x{:08X}", addr, val);
-                            }
-                        } else {
-                            println!("Usage: m/m32 <address>");
-                        }
-                    }
-                    Some("m16") => {
-                        let count = modifier.and_then(|m| m.parse::<u32>().ok()).unwrap_or(1);
-                        if let Some(addr) = addr {
-                            for i in 0..count {
-                                let addr = addr + i * 2;
-                                let val = bus.read_u16(addr);
-                                println!("[0x{:08X}] = 0x{:04X}", addr, val);
-                            }
-                        } else {
-                            println!("Usage: m16 <address>");
-                        }
-                    }
-                    Some("m8") => {
-                        let count = modifier.and_then(|m| m.parse::<u32>().ok()).unwrap_or(1);
-                        if let Some(addr) = addr {
-                            for i in 0..count {
-                                let addr = addr + i * 1;
-                                let val = bus.read_u8(addr);
-                                println!("[0x{:08X}] = 0x{:02X}", addr, val);
-                            }
-                        } else {
-                            println!("Usage: m8 <address>");
-                        }
-                    }
-                    Some("p") => {
-                        if let Some(addr) = addr {
-                            println!("0x{:08X}", addr);
-                        } else {
-                            println!("Usage: p <address>");
-                        }
-                    }
-                    Some("") => {}
-                    Some(cmd) => println!("Unknown command: {}", cmd),
-                    _ => (),
-                }
-                // make sure we send to the editor thread after we printed everything
-                // otherwise the editor thread might print the prompt in between
-                if self.paused {
-                    self.editor_tx.try_send(EditorCmd::Continue).ok();
-                }
-            }
-
+        if self.debugger.handle(&self.regs, bus) {
             return 0;
         }
 
@@ -347,17 +75,6 @@ impl Cpu {
         self.check_and_execute_interrupt(pending_interrupts);
 
         for _ in 0..clocks {
-            if !self.in_breakpoint
-                && !self.instruction_breakpoints.is_empty()
-                && self.instruction_breakpoints.contains(&self.regs.pc)
-            {
-                println!("Breakpoint hit at {:08X}", self.regs.pc);
-                self.in_breakpoint = true;
-                self.set_pause(true);
-                break;
-            }
-            self.in_breakpoint = false;
-
             if let Some(instruction) = self.bus_read_u32(bus, self.regs.pc) {
                 let instruction = Instruction::from_u32(instruction);
 
@@ -371,18 +88,16 @@ impl Cpu {
                     },
                     instruction
                 );
-                if self.instruction_trace {
-                    println!(
-                        "{:08X}: {}{}",
-                        self.regs.pc,
-                        if self.jump_dest_next.is_some() {
-                            "_"
-                        } else {
-                            ""
-                        },
-                        instruction
-                    );
+
+                // breakpoint hit
+                if self.debugger.trace_instruction(
+                    self.regs.pc,
+                    self.jump_dest_next.is_some(),
+                    &instruction,
+                ) {
+                    break;
                 }
+
                 self.regs.pc += 4;
                 if let Some(jump_dest) = self.jump_dest_next.take() {
                     log::trace!("pc jump {:08X}", jump_dest);
@@ -391,9 +106,7 @@ impl Cpu {
 
                 self.execute_instruction(&instruction, bus);
 
-                if self.step {
-                    self.set_pause(true);
-                    self.step = false;
+                if self.debugger.paused() {
                     break;
                 }
 
@@ -412,11 +125,6 @@ impl Cpu {
                 // TODO: maybe we should optimize this a bit more, so that we
                 //       won't need to check on every CPU instruction
                 if bus.should_run_dma() {
-                    break;
-                }
-
-                // can be set with write breakpoint
-                if self.paused {
                     break;
                 }
             }
@@ -1032,13 +740,7 @@ impl Cpu {
             self.execute_exception(Exception::AddressErrorStore);
             self.cop0.write_bad_vaddr(addr);
         } else {
-            if self.write_breakpoints.contains(&addr) {
-                println!(
-                    "Write Breakpoint u32 hit {:08X} at {:08X}",
-                    addr, self.regs.pc
-                );
-                self.set_pause(true);
-            }
+            self.debugger.trace_write(addr);
             match addr {
                 0x00000000..=0x00001000 if self.cop0.is_cache_isolated() => {}
                 _ => bus.write_u32(addr, data),
@@ -1065,13 +767,7 @@ impl Cpu {
             self.execute_exception(Exception::AddressErrorStore);
             self.cop0.write_bad_vaddr(addr);
         } else {
-            if self.write_breakpoints.contains(&addr) {
-                println!(
-                    "Write Breakpoint u16 hit {:08X} at {:08X}",
-                    addr, self.regs.pc
-                );
-                self.set_pause(true);
-            }
+            self.debugger.trace_write(addr);
             match addr {
                 0x00000000..=0x00001000 if self.cop0.is_cache_isolated() => {}
                 _ => bus.write_u16(addr, data),
@@ -1087,14 +783,7 @@ impl Cpu {
     }
 
     fn bus_write_u8<P: BusLine>(&mut self, bus: &mut P, addr: u32, data: u8) {
-        if self.write_breakpoints.contains(&addr) {
-            // TODO: fix the `pc` here
-            println!(
-                "Write Breakpoint u8 hit {:08X} at {:08X}",
-                addr, self.regs.pc
-            );
-            self.set_pause(true);
-        }
+        self.debugger.trace_write(addr);
         match addr {
             0x00000000..=0x00001000 if self.cop0.is_cache_isolated() => {}
             _ => bus.write_u8(addr, data),

--- a/psx-core/src/cpu.rs
+++ b/psx-core/src/cpu.rs
@@ -767,6 +767,7 @@ impl Cpu {
             return None;
         }
 
+        self.debugger.trace_read(addr, 32);
         Some(match addr {
             0x00000000..=0x00001000 if self.cop0.is_cache_isolated() => 0,
             _ => bus.read_u32(addr),
@@ -780,7 +781,7 @@ impl Cpu {
             self.execute_exception(Exception::AddressErrorStore);
             self.cop0.write_bad_vaddr(addr);
         } else {
-            self.debugger.trace_write(addr);
+            self.debugger.trace_write(addr, 32);
             match addr {
                 0x00000000..=0x00001000 if self.cop0.is_cache_isolated() => {}
                 _ => bus.write_u32(addr, data),
@@ -796,6 +797,7 @@ impl Cpu {
             return None;
         }
 
+        self.debugger.trace_read(addr, 16);
         Some(match addr {
             0x00000000..=0x00001000 if self.cop0.is_cache_isolated() => 0,
             _ => bus.read_u16(addr),
@@ -807,7 +809,7 @@ impl Cpu {
             self.execute_exception(Exception::AddressErrorStore);
             self.cop0.write_bad_vaddr(addr);
         } else {
-            self.debugger.trace_write(addr);
+            self.debugger.trace_write(addr, 16);
             match addr {
                 0x00000000..=0x00001000 if self.cop0.is_cache_isolated() => {}
                 _ => bus.write_u16(addr, data),
@@ -815,7 +817,8 @@ impl Cpu {
         }
     }
 
-    fn bus_read_u8<P: BusLine>(&self, bus: &mut P, addr: u32) -> u8 {
+    fn bus_read_u8<P: BusLine>(&mut self, bus: &mut P, addr: u32) -> u8 {
+        self.debugger.trace_read(addr, 8);
         match addr {
             0x00000000..=0x00001000 if self.cop0.is_cache_isolated() => 0,
             _ => bus.read_u8(addr),
@@ -823,7 +826,7 @@ impl Cpu {
     }
 
     fn bus_write_u8<P: BusLine>(&mut self, bus: &mut P, addr: u32, data: u8) {
-        self.debugger.trace_write(addr);
+        self.debugger.trace_write(addr, 8);
         match addr {
             0x00000000..=0x00001000 if self.cop0.is_cache_isolated() => {}
             _ => bus.write_u8(addr, data),

--- a/psx-core/src/cpu.rs
+++ b/psx-core/src/cpu.rs
@@ -36,6 +36,8 @@ pub struct Cpu {
     jump_dest_next: Option<u32>,
 
     elapsed_cycles: u32,
+
+    instruction_trace: bool,
 }
 
 impl Cpu {
@@ -48,7 +50,13 @@ impl Cpu {
             jump_dest_next: None,
 
             elapsed_cycles: 0,
+
+            instruction_trace: false,
         }
+    }
+
+    pub fn toggle_instruction_trace(&mut self) {
+        self.instruction_trace = !self.instruction_trace;
     }
 
     pub fn clock<P: CpuBusProvider>(&mut self, bus: &mut P, clocks: u32) -> u32 {
@@ -60,6 +68,9 @@ impl Cpu {
                 let instruction = Instruction::from_u32(instruction);
 
                 log::trace!("{:08X}: {}", self.regs.pc, instruction);
+                if self.instruction_trace {
+                    println!("{:08X}: {}", self.regs.pc, instruction);
+                }
                 self.regs.pc += 4;
                 if let Some(jump_dest) = self.jump_dest_next.take() {
                     log::trace!("pc jump {:08X}", jump_dest);

--- a/psx-core/src/cpu.rs
+++ b/psx-core/src/cpu.rs
@@ -1,4 +1,5 @@
 mod instruction;
+mod instruction_format;
 mod instructions_table;
 mod register;
 
@@ -58,7 +59,7 @@ impl Cpu {
             if let Some(instruction) = self.bus_read_u32(bus, self.regs.pc) {
                 let instruction = Instruction::from_u32(instruction);
 
-                log::trace!("{:08X}: {:02X?}", self.regs.pc, instruction);
+                log::trace!("{:08X}: {}", self.regs.pc, instruction);
                 self.regs.pc += 4;
                 if let Some(jump_dest) = self.jump_dest_next.take() {
                     log::trace!("pc jump {:08X}", jump_dest);
@@ -230,6 +231,9 @@ impl Cpu {
 
     fn execute_instruction<P: CpuBusProvider>(&mut self, instruction: &Instruction, bus: &mut P) {
         match instruction.opcode {
+            Opcode::Nop => {
+                // nothing
+            }
             Opcode::Lb => {
                 self.execute_load(instruction, |s, computed_addr| {
                     Some(Self::sign_extend_8(s.bus_read_u8(bus, computed_addr)))

--- a/psx-core/src/cpu/debugger.rs
+++ b/psx-core/src/cpu/debugger.rs
@@ -1,0 +1,357 @@
+use std::{collections::HashSet, io::Write, process, thread};
+
+use crossbeam::channel::{Receiver, Sender};
+use rustyline::{error::ReadlineError, Config, Editor};
+
+use crate::cpu::register;
+
+use super::{
+    instruction::Instruction,
+    instruction_format::{GENERAL_REG_NAMES, REG_HI_NAME, REG_LO_NAME, REG_PC_NAME},
+    register::{Register, Registers},
+    CpuBusProvider,
+};
+
+/// Instructing the editor thread on what to do.
+///
+/// The reason for this, is that the `Editor` object transforms the terminal
+/// to raw mode, and thus if its created, we can't Ctrl-C to kill the emulator.
+/// For better user experience, we create the editor only when needed.
+enum EditorCmd {
+    /// Create a new editor and read input
+    Start,
+    /// Continue reading input
+    Continue,
+    /// Stop reading input and destroy the editor
+    Stop,
+}
+
+fn create_editor() -> Editor<()> {
+    let conf = Config::builder().auto_add_history(true).build();
+    Editor::with_config(conf).unwrap()
+}
+
+pub struct Debugger {
+    instruction_trace: bool,
+    paused: bool,
+    instruction_breakpoints: HashSet<u32>,
+    write_breakpoints: HashSet<u32>,
+    // currently on top of breakpoint, so ignore it and continue when unpaused
+    // so that we don't get stuck in one instruction.
+    in_breakpoint: bool,
+    // allow to execute one instruction only
+    step: bool,
+    stdin_rx: Receiver<String>,
+    editor_tx: Sender<EditorCmd>,
+
+    current_pc: u32,
+}
+
+impl Debugger {
+    pub fn new() -> Self {
+        let (stdin_tx, stdin_rx) = crossbeam::channel::bounded(1);
+        let (editor_tx, editor_rx) = crossbeam::channel::bounded(1);
+
+        thread::spawn(move || {
+            let mut editor = None;
+
+            loop {
+                if let Ok(cmd) = editor_rx.recv() {
+                    match cmd {
+                        EditorCmd::Start => editor = Some(create_editor()),
+                        EditorCmd::Continue => {
+                            assert!(editor.is_some());
+                        }
+                        EditorCmd::Stop => continue,
+                    }
+                    // flush all outputs
+                    std::io::stdout().flush().unwrap();
+                    match editor.as_mut().unwrap().readline("CPU> ") {
+                        Ok(line) => {
+                            stdin_tx.send(line).unwrap();
+                        }
+                        Err(ReadlineError::Interrupted) => process::exit(0),
+                        _ => {}
+                    }
+                }
+            }
+        });
+
+        Self {
+            instruction_trace: false,
+            paused: false,
+            instruction_breakpoints: HashSet::new(),
+            write_breakpoints: HashSet::new(),
+            in_breakpoint: false,
+            step: false,
+            stdin_rx,
+            editor_tx,
+
+            current_pc: 0,
+        }
+    }
+
+    /// Pause the CPU and instructs the editor thread to start reading commands.
+    /// Note: make sure you call this function after printing all the output you
+    /// need, otherwise the editor thread might print the prompt in between your prints.
+    pub fn set_pause(&mut self, pause: bool) {
+        // only send command to editor thread
+        // if we are actually changing the state
+        if self.paused ^ pause {
+            if pause {
+                self.editor_tx.send(EditorCmd::Start).ok();
+            } else {
+                self.editor_tx.send(EditorCmd::Stop).ok();
+            }
+        }
+
+        self.paused = pause;
+    }
+
+    pub fn paused(&self) -> bool {
+        self.paused
+    }
+
+    /// Returns true if the CPU should exit and not execute instructions, since
+    /// we are paused.
+    pub fn handle<P: CpuBusProvider>(&mut self, regs: &Registers, bus: &mut P) -> bool {
+        if !self.paused {
+            return false;
+        }
+
+        if let Ok(cmd) = self.stdin_rx.try_recv() {
+            let mut tokens = cmd.trim().split_whitespace();
+            let mut cmd = tokens.next();
+            let modifier = cmd.and_then(|c| {
+                c.split_once('/').map(|(s1, s2)| {
+                    cmd = Some(s1);
+                    s2
+                })
+            });
+            let addr = tokens.next().and_then(|a| {
+                if a.starts_with('$') {
+                    let register_name = &a[1..];
+                    let register = GENERAL_REG_NAMES
+                        .iter()
+                        .position(|&r| r == register_name)
+                        .map(|i| Register::from_byte(i as u8));
+                    match register {
+                        Some(r) => Some(regs.read_register(r)),
+                        None => match register_name {
+                            REG_PC_NAME => Some(regs.pc),
+                            REG_HI_NAME => Some(regs.hi),
+                            REG_LO_NAME => Some(regs.lo),
+                            _ => {
+                                println!("Invalid register name: {}", register_name);
+                                None
+                            }
+                        },
+                    }
+                } else {
+                    let value = u32::from_str_radix(a.trim_start_matches("0x"), 16);
+                    match value {
+                        Ok(value) => Some(value),
+                        Err(_) => {
+                            println!("Invalid address: {}", a);
+                            None
+                        }
+                    }
+                }
+            });
+
+            match cmd {
+                Some("h") => {
+                    println!("h - help");
+                    println!("r - print registers");
+                    println!("c - continue");
+                    println!("s - step");
+                    println!("tt - enable trace");
+                    println!("tf - disbale trace");
+                    println!("stack [0xn] - print stack [n entries in hex]");
+                    println!("b <addr> - set breakpoint");
+                    println!("rb <addr> - remove breakpoint");
+                    println!("wb <addr> - set write breakpoint");
+                    println!("wrb <addr> - remove write breakpoint");
+                    println!("lb - list breakpoints");
+                    println!("m[32/16/8] <addr> - print content of memory (default u32)");
+                    println!("p <addr>/<$reg> - print address or register value");
+                }
+                Some("r") => regs.debug_print(),
+                Some("c") => self.set_pause(false),
+                Some("s") => {
+                    self.set_pause(false);
+                    self.step = true;
+                }
+                Some("tt") => self.set_instruction_trace(true),
+                Some("tf") => self.set_instruction_trace(false),
+                Some("stack") => {
+                    let n = addr.unwrap_or(10);
+                    let sp = regs.read_register(register::RegisterType::Sp.into());
+                    println!("Stack: SP=0x{:08X}", sp);
+                    for i in 0..n {
+                        println!("    {:08X}", bus.read_u32(sp + i * 4));
+                    }
+                }
+                Some("b") => {
+                    if let Some(addr) = addr {
+                        self.add_breakpoint(addr);
+                    } else {
+                        println!("Usage: b <address>");
+                    }
+                }
+                Some("rb") => {
+                    if let Some(addr) = addr {
+                        self.remove_breakpoint(addr);
+                    } else {
+                        println!("Usage: rb <address>");
+                    }
+                }
+                Some("wb") => {
+                    if let Some(addr) = addr {
+                        self.add_write_breakpoint(addr);
+                    } else {
+                        println!("Usage: wb <address>");
+                    }
+                }
+                Some("wrb") => {
+                    if let Some(addr) = addr {
+                        self.remove_write_breakpoint(addr);
+                    } else {
+                        println!("Usage: wrb <address>");
+                    }
+                }
+                Some("lb") => {
+                    for bp in self.instruction_breakpoints.iter() {
+                        println!("Breakpoint: 0x{:08X}", bp);
+                    }
+                    for bp in self.write_breakpoints.iter() {
+                        println!("Write Breakpoint: 0x{:08X}", bp);
+                    }
+                }
+                Some("m") | Some("m32") => {
+                    let count = modifier.and_then(|m| m.parse::<u32>().ok()).unwrap_or(1);
+                    if let Some(addr) = addr {
+                        for i in 0..count {
+                            let addr = addr + i * 4;
+                            let val = bus.read_u32(addr);
+                            println!("[0x{:08X}] = 0x{:08X}", addr, val);
+                        }
+                    } else {
+                        println!("Usage: m/m32 <address>");
+                    }
+                }
+                Some("m16") => {
+                    let count = modifier.and_then(|m| m.parse::<u32>().ok()).unwrap_or(1);
+                    if let Some(addr) = addr {
+                        for i in 0..count {
+                            let addr = addr + i * 2;
+                            let val = bus.read_u16(addr);
+                            println!("[0x{:08X}] = 0x{:04X}", addr, val);
+                        }
+                    } else {
+                        println!("Usage: m16 <address>");
+                    }
+                }
+                Some("m8") => {
+                    let count = modifier.and_then(|m| m.parse::<u32>().ok()).unwrap_or(1);
+                    if let Some(addr) = addr {
+                        for i in 0..count {
+                            let addr = addr + i * 1;
+                            let val = bus.read_u8(addr);
+                            println!("[0x{:08X}] = 0x{:02X}", addr, val);
+                        }
+                    } else {
+                        println!("Usage: m8 <address>");
+                    }
+                }
+                Some("p") => {
+                    if let Some(addr) = addr {
+                        println!("0x{:08X}", addr);
+                    } else {
+                        println!("Usage: p <address>");
+                    }
+                }
+                Some("") => {}
+                Some(cmd) => println!("Unknown command: {}", cmd),
+                _ => (),
+            }
+            // make sure we send to the editor thread after we printed everything
+            // otherwise the editor thread might print the prompt in between
+            if self.paused {
+                self.editor_tx.try_send(EditorCmd::Continue).ok();
+            }
+        }
+
+        return true;
+    }
+
+    pub fn trace_instruction(&mut self, pc: u32, jumping: bool, instruction: &Instruction) -> bool {
+        self.current_pc = pc;
+
+        if !self.in_breakpoint
+            && !self.instruction_breakpoints.is_empty()
+            && self.instruction_breakpoints.contains(&pc)
+        {
+            println!("Breakpoint hit at {:08X}", pc);
+            self.in_breakpoint = true;
+            self.set_pause(true);
+            return true;
+        }
+
+        self.in_breakpoint = false;
+
+        if self.instruction_trace {
+            println!(
+                "{:08X}: {}{}",
+                pc,
+                if jumping { "_" } else { "" },
+                instruction
+            );
+        }
+
+        if self.step {
+            self.set_pause(true);
+            self.step = false;
+        }
+
+        // even if we are in step breakpoint, we must execute the current instruction
+        false
+    }
+
+    pub fn trace_write(&mut self, addr: u32) {
+        if self.write_breakpoints.contains(&addr) {
+            println!(
+                "Write Breakpoint u32 hit {:08X} at {:08X}",
+                addr, self.current_pc
+            );
+            self.set_pause(true);
+        }
+    }
+}
+
+impl Debugger {
+    fn set_instruction_trace(&mut self, trace: bool) {
+        self.instruction_trace = trace;
+        println!("Instruction trace: {}", self.instruction_trace);
+    }
+
+    fn add_breakpoint(&mut self, address: u32) {
+        self.instruction_breakpoints.insert(address);
+        println!("Breakpoint added: 0x{:08X}", address);
+    }
+
+    fn remove_breakpoint(&mut self, address: u32) {
+        self.instruction_breakpoints.remove(&address);
+        println!("Breakpoint removed: 0x{:08X}", address);
+    }
+
+    fn add_write_breakpoint(&mut self, address: u32) {
+        self.write_breakpoints.insert(address);
+        println!("Write Breakpoint added: 0x{:08X}", address);
+    }
+
+    fn remove_write_breakpoint(&mut self, address: u32) {
+        self.write_breakpoints.remove(&address);
+        println!("Write Breakpoint removed: 0x{:08X}", address);
+    }
+}

--- a/psx-core/src/cpu/debugger.rs
+++ b/psx-core/src/cpu/debugger.rs
@@ -282,7 +282,7 @@ impl Debugger {
             }
         }
 
-        return true;
+        true
     }
 
     pub fn trace_instruction(&mut self, pc: u32, jumping: bool, instruction: &Instruction) -> bool {

--- a/psx-core/src/cpu/instruction.rs
+++ b/psx-core/src/cpu/instruction.rs
@@ -107,6 +107,8 @@ pub enum Opcode {
 
 #[derive(Debug)]
 pub struct Instruction {
+    pub pc: u32,
+
     pub opcode: Opcode,
 
     pub imm5: u8,
@@ -122,9 +124,11 @@ pub struct Instruction {
 }
 
 impl Instruction {
-    pub fn from_u32(instruction: u32) -> Self {
+    pub fn from_u32(instruction: u32, pc: u32) -> Self {
         if instruction == 0 {
             return Self {
+                pc,
+
                 opcode: Opcode::Nop,
                 imm5: 0,
                 rd_raw: 0,
@@ -163,6 +167,8 @@ impl Instruction {
         };
 
         Self {
+            pc,
+
             opcode,
             imm5,
             rd_raw,
@@ -174,6 +180,24 @@ impl Instruction {
             imm16,
             imm25,
             imm26,
+        }
+    }
+
+    pub fn is_branch(&self) -> bool {
+        match self.opcode {
+            Opcode::J
+            | Opcode::Jal
+            | Opcode::Jalr
+            | Opcode::Jr
+            | Opcode::Beq
+            | Opcode::Bne
+            | Opcode::Bgtz
+            | Opcode::Blez
+            | Opcode::Bltz
+            | Opcode::Bgez
+            | Opcode::Bltzal
+            | Opcode::Bgezal => true,
+            _ => false,
         }
     }
 }

--- a/psx-core/src/cpu/instruction.rs
+++ b/psx-core/src/cpu/instruction.rs
@@ -105,7 +105,7 @@ pub enum Opcode {
     Swc(u8),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Instruction {
     pub pc: u32,
 

--- a/psx-core/src/cpu/instruction.rs
+++ b/psx-core/src/cpu/instruction.rs
@@ -183,6 +183,7 @@ impl Instruction {
         }
     }
 
+    #[allow(dead_code)]
     pub fn is_branch(&self) -> bool {
         match self.opcode {
             Opcode::J

--- a/psx-core/src/cpu/instruction.rs
+++ b/psx-core/src/cpu/instruction.rs
@@ -6,6 +6,8 @@ pub enum Opcode {
     Special,
     Invalid,
 
+    Nop,
+
     // (u) means unsigned, (t) means overflow trap, (i) means immediate
     Lb,
     Lbu,
@@ -121,6 +123,22 @@ pub struct Instruction {
 
 impl Instruction {
     pub fn from_u32(instruction: u32) -> Self {
+        if instruction == 0 {
+            return Self {
+                opcode: Opcode::Nop,
+                imm5: 0,
+                rd_raw: 0,
+                rd: Register::from_byte(0),
+                rt_raw: 0,
+                rt: Register::from_byte(0),
+                rs_raw: 0,
+                rs: Register::from_byte(0),
+                imm16: 0,
+                imm25: 0,
+                imm26: 0,
+            };
+        }
+
         let primary_identifier = (instruction >> 26) as u8;
         let secondary_identifier = instruction as u8 & 0x3F;
         let imm5 = (instruction >> 6) as u8 & 0x1F;

--- a/psx-core/src/cpu/instruction_format.rs
+++ b/psx-core/src/cpu/instruction_format.rs
@@ -1,0 +1,280 @@
+use std::fmt;
+
+use super::{
+    instruction::{Instruction, Opcode},
+    register::Register,
+};
+
+const fn opcode_str(opcode: Opcode) -> &'static str {
+    match opcode {
+        Opcode::Nop => "nop",
+        Opcode::Lb => "lb",
+        Opcode::Lh => "lh",
+        Opcode::Lw => "lw",
+        Opcode::Lbu => "lbu",
+        Opcode::Lhu => "lhu",
+        Opcode::Sb => "sb",
+        Opcode::Lwl => "lwl",
+        Opcode::Lwr => "lwr",
+        Opcode::Sh => "sh",
+        Opcode::Sw => "sw",
+        Opcode::Swl => "swl",
+        Opcode::Swr => "swr",
+        Opcode::Slt => "slt",
+        Opcode::Sltu => "sltu",
+        Opcode::Slti => "slti",
+        Opcode::Sltiu => "sltiu",
+        Opcode::Addu => "addu",
+        Opcode::Add => "add",
+        Opcode::Subu => "subu",
+        Opcode::Sub => "sub",
+        Opcode::Addiu => "addiu",
+        Opcode::Addi => "addi",
+        Opcode::And => "and",
+        Opcode::Or => "or",
+        Opcode::Xor => "xor",
+        Opcode::Nor => "nor",
+        Opcode::Andi => "andi",
+        Opcode::Ori => "ori",
+        Opcode::Xori => "xori",
+        Opcode::Sllv => "sllv",
+        Opcode::Srlv => "srlv",
+        Opcode::Srav => "srav",
+        Opcode::Sll => "sll",
+        Opcode::Srl => "srl",
+        Opcode::Sra => "sra",
+        Opcode::Lui => "lui",
+        Opcode::Mult => "mult",
+        Opcode::Multu => "multu",
+        Opcode::Div => "div",
+        Opcode::Divu => "divu",
+        Opcode::Mfhi => "mfhi",
+        Opcode::Mthi => "mthi",
+        Opcode::Mflo => "mflo",
+        Opcode::Mtlo => "mtlo",
+        Opcode::J => "j",
+        Opcode::Jal => "jal",
+        Opcode::Jr => "jr",
+        Opcode::Jalr => "jalr",
+        Opcode::Beq => "beq",
+        Opcode::Bne => "bne",
+        Opcode::Bgtz => "bgtz",
+        Opcode::Blez => "blez",
+        Opcode::Bcondz => "bcondz",
+        Opcode::Bltz => "bltz",
+        Opcode::Bgez => "bgez",
+        Opcode::Bltzal => "bltzal",
+        Opcode::Bgezal => "bgezal",
+        Opcode::Syscall => "syscall",
+        Opcode::Break => "break",
+        Opcode::Cop(0) => "cop0",
+        Opcode::Cop(1) => "cop1",
+        Opcode::Cop(2) => "cop2",
+        Opcode::Cop(3) => "cop3",
+        Opcode::Mfc(0) => "mfc0",
+        Opcode::Mfc(1) => "mfc1",
+        Opcode::Mfc(2) => "mfc2",
+        Opcode::Mfc(3) => "mfc3",
+        Opcode::Cfc(0) => "cfc0",
+        Opcode::Cfc(1) => "cfc1",
+        Opcode::Cfc(2) => "cfc2",
+        Opcode::Cfc(3) => "cfc3",
+        Opcode::Mtc(0) => "mtc0",
+        Opcode::Mtc(1) => "mtc1",
+        Opcode::Mtc(2) => "mtc2",
+        Opcode::Mtc(3) => "mtc3",
+        Opcode::Ctc(0) => "ctc0",
+        Opcode::Ctc(1) => "ctc1",
+        Opcode::Ctc(2) => "ctc2",
+        Opcode::Ctc(3) => "ctc3",
+        Opcode::Bcf(0) => "bcf0",
+        Opcode::Bcf(1) => "bcf1",
+        Opcode::Bcf(2) => "bcf2",
+        Opcode::Bcf(3) => "bcf3",
+        Opcode::Bct(0) => "bct0",
+        Opcode::Bct(1) => "bct1",
+        Opcode::Bct(2) => "bct2",
+        Opcode::Bct(3) => "bct3",
+        Opcode::Rfe => "rfe",
+        Opcode::Lwc(0) => "lwc0",
+        Opcode::Lwc(1) => "lwc1",
+        Opcode::Lwc(2) => "lwc2",
+        Opcode::Lwc(3) => "lwc3",
+        Opcode::Swc(0) => "swc0",
+        Opcode::Swc(1) => "swc1",
+        Opcode::Swc(2) => "swc2",
+        Opcode::Swc(3) => "swc3",
+        _ => unreachable!(),
+    }
+}
+
+const REG_NAMES: [&str; 32] = [
+    "zero", "at", "v0", "v1", "a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6",
+    "t7", "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "t8", "t9", "k0", "k1", "gp", "sp", "fp",
+    "ra",
+];
+
+impl fmt::Display for Register {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(REG_NAMES[self.idx() as usize])
+    }
+}
+
+fn format_load_store(f: &mut fmt::Formatter, instruction: &Instruction) -> fmt::Result {
+    let opcode = instruction.opcode;
+
+    let src = instruction.rs;
+    let off = instruction.imm16;
+    let dst = instruction.rt;
+
+    write!(f, "{} {}, 0x{:04X}({})", opcode_str(opcode), dst, off, src)
+}
+
+fn format_alu(f: &mut fmt::Formatter, instruction: &Instruction, imm: bool) -> fmt::Result {
+    let opcode = instruction.opcode;
+
+    let (first, third) = if imm {
+        (instruction.rt, format!("0x{:04X}", instruction.imm16))
+    } else {
+        (instruction.rd, format!("{}", instruction.rt))
+    };
+
+    write!(
+        f,
+        "{} {}, {}, {}",
+        opcode_str(opcode),
+        first,
+        instruction.rs,
+        third
+    )
+}
+
+fn format_shift(f: &mut fmt::Formatter, instruction: &Instruction, imm: bool) -> fmt::Result {
+    let opcode = instruction.opcode;
+
+    let third = if imm {
+        format!("0x{:02X}", instruction.imm5)
+    } else {
+        format!("{}", instruction.rs)
+    };
+
+    write!(
+        f,
+        "{} {}, {}, {}",
+        opcode_str(opcode),
+        instruction.rd,
+        instruction.rt,
+        third
+    )
+}
+
+fn format_mult_div(f: &mut fmt::Formatter, instruction: &Instruction) -> fmt::Result {
+    let opcode = instruction.opcode;
+
+    write!(
+        f,
+        "{} {}, {}",
+        opcode_str(opcode),
+        instruction.rs,
+        instruction.rt
+    )
+}
+
+fn format_branch(f: &mut fmt::Formatter, instruction: &Instruction, rt: bool) -> fmt::Result {
+    let opcode = instruction.opcode;
+
+    let dest = instruction.imm16;
+
+    if rt {
+        write!(
+            f,
+            "{} {}, {}, 0x{:04X}",
+            opcode_str(opcode),
+            instruction.rs,
+            instruction.rt,
+            dest
+        )
+    } else {
+        write!(
+            f,
+            "{} {}, 0x{:04X}",
+            opcode_str(opcode),
+            instruction.rs,
+            dest
+        )
+    }
+}
+
+fn format_cop_ops(f: &mut fmt::Formatter, instruction: &Instruction) -> fmt::Result {
+    let opcode = instruction.opcode;
+
+    write!(
+        f,
+        "{} {}, {}",
+        opcode_str(opcode),
+        instruction.rt,
+        instruction.rd
+    )
+}
+
+impl fmt::Display for Instruction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.opcode {
+            Opcode::Lb
+            | Opcode::Lbu
+            | Opcode::Lh
+            | Opcode::Lhu
+            | Opcode::Lw
+            | Opcode::Lwl
+            | Opcode::Lwr
+            | Opcode::Sb
+            | Opcode::Sh
+            | Opcode::Sw
+            | Opcode::Swl
+            | Opcode::Swr => format_load_store(f, self),
+            Opcode::Slt | Opcode::Sltu => format_alu(f, self, false),
+            Opcode::Slti | Opcode::Sltiu => format_alu(f, self, true),
+            Opcode::Addu | Opcode::Add | Opcode::Subu | Opcode::Sub => format_alu(f, self, false),
+            Opcode::Addiu | Opcode::Addi => format_alu(f, self, true),
+            Opcode::And | Opcode::Or | Opcode::Xor | Opcode::Nor => format_alu(f, self, false),
+            Opcode::Andi | Opcode::Ori | Opcode::Xori => format_alu(f, self, true),
+            Opcode::Sllv | Opcode::Srlv | Opcode::Srav => format_shift(f, self, false),
+            Opcode::Sll | Opcode::Srl | Opcode::Sra => format_shift(f, self, true),
+            Opcode::Lui => write!(
+                f,
+                "{} {}, 0x{:04X}",
+                opcode_str(self.opcode),
+                self.rt,
+                self.imm16
+            ),
+            Opcode::Mult | Opcode::Multu | Opcode::Div | Opcode::Divu => format_mult_div(f, self),
+            Opcode::Mfhi => write!(f, "{} {}", opcode_str(self.opcode), self.rd),
+            Opcode::Mthi => write!(f, "{} {}", opcode_str(self.opcode), self.rs),
+            Opcode::Mflo => write!(f, "{} {}", opcode_str(self.opcode), self.rd),
+            Opcode::Mtlo => write!(f, "{} {}", opcode_str(self.opcode), self.rs),
+            Opcode::J => write!(f, "{} 0x{:07X}", opcode_str(self.opcode), self.imm26),
+            Opcode::Jal => write!(f, "{} 0x{:07X}", opcode_str(self.opcode), self.imm26),
+            Opcode::Jr => write!(f, "{} {}", opcode_str(self.opcode), self.rs),
+            // some specs says "jalr rd,rs"
+            Opcode::Jalr => write!(f, "{} {}, {}", opcode_str(self.opcode), self.rs, self.rd),
+            Opcode::Beq | Opcode::Bne => format_branch(f, self, true),
+            Opcode::Bgtz
+            | Opcode::Blez
+            | Opcode::Bltz
+            | Opcode::Bgez
+            | Opcode::Bltzal
+            | Opcode::Bgezal => format_branch(f, self, false),
+            Opcode::Nop | Opcode::Syscall | Opcode::Break | Opcode::Rfe => {
+                f.write_str(opcode_str(self.opcode))
+            }
+            Opcode::Cop(_) => write!(f, "{} 0x{:07X}", opcode_str(self.opcode), self.imm25),
+            Opcode::Mfc(_) | Opcode::Cfc(_) | Opcode::Mtc(_) | Opcode::Ctc(_) => {
+                format_cop_ops(f, self)
+            }
+            Opcode::Bcf(_) => todo!(),
+            Opcode::Bct(_) => todo!(),
+            Opcode::Lwc(_) | Opcode::Swc(_) => format_load_store(f, self),
+            _ => panic!(),
+        }
+    }
+}

--- a/psx-core/src/cpu/instruction_format.rs
+++ b/psx-core/src/cpu/instruction_format.rs
@@ -108,15 +108,18 @@ const fn opcode_str(opcode: Opcode) -> &'static str {
     }
 }
 
-pub const REG_NAMES: [&str; 32] = [
+pub const GENERAL_REG_NAMES: [&str; 32] = [
     "zero", "at", "v0", "v1", "a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6",
     "t7", "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "t8", "t9", "k0", "k1", "gp", "sp", "fp",
     "ra",
 ];
+pub const REG_PC_NAME: &str = "pc";
+pub const REG_HI_NAME: &str = "hi";
+pub const REG_LO_NAME: &str = "lo";
 
 impl fmt::Display for Register {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(REG_NAMES[self.idx() as usize])
+        f.write_str(GENERAL_REG_NAMES[self.idx() as usize])
     }
 }
 

--- a/psx-core/src/cpu/instruction_format.rs
+++ b/psx-core/src/cpu/instruction_format.rs
@@ -113,8 +113,11 @@ pub const GENERAL_REG_NAMES: [&str; 32] = [
     "t7", "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "t8", "t9", "k0", "k1", "gp", "sp", "fp",
     "ra",
 ];
+#[allow(dead_code)]
 pub const REG_PC_NAME: &str = "pc";
+#[allow(dead_code)]
 pub const REG_HI_NAME: &str = "hi";
+#[allow(dead_code)]
 pub const REG_LO_NAME: &str = "lo";
 
 impl fmt::Display for Register {

--- a/psx-core/src/cpu/instruction_format.rs
+++ b/psx-core/src/cpu/instruction_format.rs
@@ -120,6 +120,13 @@ pub const REG_HI_NAME: &str = "hi";
 #[allow(dead_code)]
 pub const REG_LO_NAME: &str = "lo";
 
+#[allow(dead_code)]
+pub const ALL_REG_NAMES: [&str; 35] = [
+    "zero", "at", "v0", "v1", "a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6",
+    "t7", "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "t8", "t9", "k0", "k1", "gp", "sp", "fp",
+    "ra", "pc", "hi", "lo",
+];
+
 impl fmt::Display for Register {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(GENERAL_REG_NAMES[self.idx() as usize])

--- a/psx-core/src/cpu/instruction_format.rs
+++ b/psx-core/src/cpu/instruction_format.rs
@@ -108,7 +108,7 @@ const fn opcode_str(opcode: Opcode) -> &'static str {
     }
 }
 
-const REG_NAMES: [&str; 32] = [
+pub const REG_NAMES: [&str; 32] = [
     "zero", "at", "v0", "v1", "a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6",
     "t7", "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "t8", "t9", "k0", "k1", "gp", "sp", "fp",
     "ra",

--- a/psx-core/src/cpu/register.rs
+++ b/psx-core/src/cpu/register.rs
@@ -132,6 +132,7 @@ impl Registers {
 }
 
 impl Registers {
+    #[cfg(feature = "debugger")]
     pub fn debug_print(&self) {
         println!("Registers:");
 

--- a/psx-core/src/cpu/register.rs
+++ b/psx-core/src/cpu/register.rs
@@ -62,6 +62,11 @@ impl Register {
     pub fn from_byte(idx: u8) -> Self {
         Register { idx: idx & 0x1F }
     }
+
+    #[inline]
+    pub fn idx(&self) -> u8 {
+        self.idx
+    }
 }
 
 impl From<Register> for RegisterType {

--- a/psx-core/src/cpu/register.rs
+++ b/psx-core/src/cpu/register.rs
@@ -135,22 +135,34 @@ impl Registers {
     pub fn debug_print(&self) {
         println!("Registers:");
 
+        // print PC and AT
         println!(
             "pc: {:08X}\t{:>4}: {:08X}",
             self.pc,
             Register::from_byte(1),
             self.general_regs[1]
         );
+        // HI and LO
         println!("hi: {:08X}\tlo: {:08X}", self.hi, self.lo);
 
+        // print all other registers except the last two
         for i in 2..32 / 2 {
             println!(
                 "{:>4}: {:08X}\t{:>4}: {:08X}",
                 Register::from_byte(i),
                 self.general_regs[i as usize],
-                Register::from_byte(i + 32 / 2),
-                self.general_regs[(i + 32 / 2) as usize]
+                // -2 offset because we are not printing 0 (ZERO) and 1 (AT)
+                Register::from_byte(i + 32 / 2 - 2),
+                self.general_regs[(i + 32 / 2 - 2) as usize]
             );
         }
+        // print the last two registers
+        println!(
+            "{:>4}: {:08X}\t{:>4}: {:08X}",
+            Register::from_byte(30),
+            self.general_regs[30],
+            Register::from_byte(31),
+            self.general_regs[31]
+        );
     }
 }

--- a/psx-core/src/cpu/register.rs
+++ b/psx-core/src/cpu/register.rs
@@ -130,3 +130,27 @@ impl Registers {
         self.general_regs[31] = data;
     }
 }
+
+impl Registers {
+    pub fn debug_print(&self) {
+        println!("Registers:");
+
+        println!(
+            "pc: {:08X}\t{:>4}: {:08X}",
+            self.pc,
+            Register::from_byte(1),
+            self.general_regs[1]
+        );
+        println!("hi: {:08X}\tlo: {:08X}", self.hi, self.lo);
+
+        for i in 2..32 / 2 {
+            println!(
+                "{:>4}: {:08X}\t{:>4}: {:08X}",
+                Register::from_byte(i),
+                self.general_regs[i as usize],
+                Register::from_byte(i + 32 / 2),
+                self.general_regs[(i + 32 / 2) as usize]
+            );
+        }
+    }
+}

--- a/psx-core/src/lib.rs
+++ b/psx-core/src/lib.rs
@@ -93,6 +93,7 @@ impl Psx {
 
     pub fn pause_cpu(&mut self) {
         self.cpu.set_pause(true);
+        #[cfg(feature = "debugger")]
         self.cpu.print_cpu_registers();
     }
 }

--- a/psx-core/src/lib.rs
+++ b/psx-core/src/lib.rs
@@ -87,4 +87,8 @@ impl Psx {
             .gpu_mut()
             .sync_gpu_and_blit_to_front(dest_image, full_vram, in_future);
     }
+
+    pub fn toggle_instruction_trace(&mut self) {
+        self.cpu.toggle_instruction_trace();
+    }
 }

--- a/psx-core/src/lib.rs
+++ b/psx-core/src/lib.rs
@@ -61,6 +61,9 @@ impl Psx {
             // this number doesn't mean anything
             // TODO: research on when to stop the CPU (maybe fixed number? block of code? other?)
             let cpu_cycles = self.cpu.clock(&mut self.bus, 32);
+            if cpu_cycles == 0 {
+                return true;
+            }
             // the DMA is running of the CPU
             self.excess_cpu_cycles = cpu_cycles + self.bus.clock_dma();
         }
@@ -88,7 +91,8 @@ impl Psx {
             .sync_gpu_and_blit_to_front(dest_image, full_vram, in_future);
     }
 
-    pub fn toggle_instruction_trace(&mut self) {
-        self.cpu.toggle_instruction_trace();
+    pub fn pause_cpu(&mut self) {
+        self.cpu.set_pause(true);
+        self.cpu.print_cpu_registers();
     }
 }

--- a/psx-core/src/memory.rs
+++ b/psx-core/src/memory.rs
@@ -1,5 +1,7 @@
 mod dma;
 mod expansion_regions;
+#[cfg(feature = "debugger")]
+pub(crate) mod hw_registers;
 pub(crate) mod interrupts;
 mod memory_control;
 mod ram;

--- a/psx-core/src/memory/hw_registers.rs
+++ b/psx-core/src/memory/hw_registers.rs
@@ -1,0 +1,49 @@
+pub static HW_REGISTERS: phf::Map<&'static str, u32> = phf::phf_map! {
+    // Gpu
+    "GPU_STAT" => 0x1F801814,
+
+    // Interrupts
+    "INT_STAT" => 0x1F801070,
+    "INT_MASK" => 0x1F801074,
+
+    // Dma
+    "DMA_MDECIN_MADR" => 0x1F801080,
+    "DMA_MDECIN_BCR" => 0x1F801084,
+    "DMA_MDECIN_CHCR" => 0x1F801088,
+    "DMA_MDECOUT_MADR" => 0x1F801090,
+    "DMA_MDECOUT_BCR" => 0x1F801094,
+    "DMA_MDECOUT_CHCR" => 0x1F801098,
+    "DMA_GPU_MADR" => 0x1F8010A0,
+    "DMA_GPU_BCR" => 0x1F8010A4,
+    "DMA_GPU_CHCR" => 0x1F8010A8,
+    "DMA_CDROM_MADR" => 0x1F8010B0,
+    "DMA_CDROM_BCR" => 0x1F8010B4,
+    "DMA_CDROM_CHCR" => 0x1F8010B8,
+    "DMA_SPU_MADR" => 0x1F8010C0,
+    "DMA_SPU_BCR" => 0x1F8010C4,
+    "DMA_SPU_CHCR" => 0x1F8010C8,
+    "DMA_PIO_MADR" => 0x1F8010D0,
+    "DMA_PIO_BCR" => 0x1F8010D4,
+    "DMA_PIO_CHCR" => 0x1F8010D8,
+    "DMA_OTC_MADR" => 0x1F8010E0,
+    "DMA_OTC_BCR" => 0x1F8010E4,
+    "DMA_OTC_CHCR" => 0x1F8010E8,
+    "DMA_CONTROL" => 0x1F8010F0,
+    "DMA_INTERRUPT" => 0x1F8010F4,
+
+    // Timers
+    "TIMER0_COUNTER" => 0x1F801100,
+    // "TIMER0_MODE" => 0x1F801104, // TODO: this reset after read, we can'the
+                                    // make the debugger reset it
+    "TIMER0_TARGET" => 0x1F801108,
+    "TIMER1_COUNTER" => 0x1F801110,
+    // "TIMER1_MODE" => 0x1F801114,
+    "TIMER1_TARGET" => 0x1F801118,
+    "TIMER2_COUNTER" => 0x1F801120,
+    // "TIMER2_MODE" => 0x1F801124,
+    "TIMER2_TARGET" => 0x1F801128,
+
+    // MDEC
+    // "MDEC_DATA" => 0x1F801820, // TODO: reading this pulls from the fifo
+    "MDEC_STATUS" => 0x1F801824,
+};

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,7 +336,8 @@ fn main() {
                         psx.change_controller_key_state(k, pressed);
                     } else if pressed {
                         match input.virtual_keycode {
-                            Some(VirtualKeyCode::Slash) => psx.toggle_instruction_trace(),
+                            // Pause CPU and enable debug
+                            Some(VirtualKeyCode::Slash) => psx.pause_cpu(),
                             _ => {}
                         }
                     }
@@ -350,6 +351,9 @@ fn main() {
         for _ in 0..100 {
             if psx.clock() {
                 display.render_frame(&mut psx);
+                // break, so that when we are in debug mode, it will not hang
+                // since it will return `true` always in that case.
+                break;
             }
         }
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -334,6 +334,11 @@ fn main() {
                     };
                     if let Some(k) = digital_key {
                         psx.change_controller_key_state(k, pressed);
+                    } else if pressed {
+                        match input.virtual_keycode {
+                            Some(VirtualKeyCode::Slash) => psx.toggle_instruction_trace(),
+                            _ => {}
+                        }
                     }
                 }
                 _ => {}


### PR DESCRIPTION
Powerful CPU debugger, with many features:

- Stepping
- Stepping over functions
- Print stack
- Print backtrace
- Read/Write/Exec breakpooints
- Read memory
- Disassemble instructions
- Readline REPL style with history
- Read CPU registers by name with `$`
- Read hardware registers by name with `@`

The debugger is gated by `debugger` feature. which is enabled by default for the frontend `psx`.

Note: command input handling is done by the backend `psx-core` through the tty, which is not ideal for automated access, maybe this should be converted into an API interface.

Also, when the DMA writes to ram, we don't track that. and no Write/Read breakpoints occur.