### PR TITLE
Gpu improvements and fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,24 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,10 +52,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "ash"
-version = "0.36.0+1.3.206"
+name = "arrayref"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceea9c64653169f33f946debf0a41568afc4e23a4c37d29004a23b2ffbfb4034"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "ash"
+version = "0.37.1+1.3.235"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911015c962d56e2e4052f40182ca5462ba60a3d2ff04e827c365a0ab3d65726d"
 dependencies = [
  "libloading",
 ]
@@ -130,12 +160,15 @@ checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "calloop"
-version = "0.9.3"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf2eec61efe56aa1e813f5126959296933cf0700030e4314786c48779a66ab82"
+checksum = "5bcf530afb40e45e14440701e5e996d7fd139e84a912a4d83a8d6a0fb3e58663"
 dependencies = [
  "log",
- "nix 0.22.3",
+ "nix 0.25.1",
+ "slotmap",
+ "thiserror",
+ "vec_map",
 ]
 
 [[package]]
@@ -161,12 +194,6 @@ checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -246,21 +273,6 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c49e86fc36d5704151f5996b7b3795385f50ce09e3be0f47a0cfde869681cf8"
-dependencies = [
- "bitflags",
- "block",
- "core-foundation 0.7.0",
- "core-graphics 0.19.2",
- "foreign-types",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f63902e9223530efb4e26ccd0cf55ec30d592d3b42e21a28defc42a9586e832"
@@ -268,9 +280,9 @@ dependencies = [
  "bitflags",
  "block",
  "cocoa-foundation",
- "core-foundation 0.9.3",
- "core-graphics 0.22.3",
- "foreign-types",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types 0.3.2",
  "libc",
  "objc",
 ]
@@ -283,9 +295,9 @@ checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
 dependencies = [
  "bitflags",
  "block",
- "core-foundation 0.9.3",
+ "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "objc",
 ]
@@ -302,29 +314,13 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
-dependencies = [
- "core-foundation-sys 0.7.0",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
- "core-foundation-sys 0.8.3",
+ "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
@@ -334,26 +330,14 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "core-graphics"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
-dependencies = [
- "bitflags",
- "core-foundation 0.7.0",
- "foreign-types",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.3",
+ "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
@@ -364,22 +348,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.3",
- "foreign-types",
+ "core-foundation",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
 [[package]]
-name = "core-video-sys"
-version = "0.1.4"
+name = "core-text"
+version = "19.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ecad23610ad9757664d644e369246edde1803fcb43ed72876565098a5d3828"
+checksum = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
 dependencies = [
- "cfg-if 0.1.10",
- "core-foundation-sys 0.7.0",
- "core-graphics 0.19.2",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types 0.3.2",
  "libc",
- "objc",
 ]
 
 [[package]]
@@ -408,7 +391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d466b47cf0ea4100186a7c12d7d0166813dda7cf648553554c9c39c6324841b"
 dependencies = [
  "alsa",
- "core-foundation-sys 0.8.3",
+ "core-foundation-sys",
  "coreaudio-rs",
  "jni",
  "js-sys",
@@ -419,11 +402,20 @@ dependencies = [
  "nix 0.23.1",
  "oboe",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "stdweb",
  "thiserror",
  "web-sys",
  "windows",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -432,7 +424,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -446,7 +438,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -456,7 +448,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -468,7 +460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "memoffset",
  "once_cell",
@@ -481,7 +473,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -491,9 +483,38 @@ version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
+
+[[package]]
+name = "crossfont"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21fd3add36ea31aba1520aa5288714dd63be506106753226d0eb387a93bc9c45"
+dependencies = [
+ "cocoa",
+ "core-foundation",
+ "core-foundation-sys",
+ "core-graphics",
+ "core-text",
+ "dwrote",
+ "foreign-types 0.5.0",
+ "freetype-rs",
+ "libc",
+ "log",
+ "objc",
+ "once_cell",
+ "pkg-config",
+ "servo-fontconfig",
+ "winapi",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "cty"
@@ -558,6 +579,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "dwrote"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "serde",
+ "serde_derive",
+ "winapi",
+ "wio",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,14 +635,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "expat-sys"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa"
+dependencies = [
+ "cmake",
+ "pkg-config",
+]
+
+[[package]]
 name = "fd-lock"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e11dcc7e4d79a8c89b9ab4c6f5c30b1fc4a83c420792da3542fd31179ed5f517"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -622,7 +677,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8469d0d40519bc608ec6863f1cc88f3f1deee15913f2f3b3e573d81ed38cccc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -632,6 +708,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "freetype-rs"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74eadec9d0a5c28c54bb9882e54787275152a4e36ce206b45d7451384e5bf5fb"
+dependencies = [
+ "bitflags",
+ "freetype-sys",
+ "libc",
+]
+
+[[package]]
+name = "freetype-sys"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37d4011c0cc628dfa766fcc195454f4b068d7afdc2adfd28861191d866e731a"
+dependencies = [
+ "cmake",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,9 +754,12 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -686,7 +804,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -756,9 +874,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "libloading"
@@ -766,7 +884,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "winapi",
 ]
 
@@ -792,7 +910,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -821,9 +939,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.3.1"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b6c2ebff6180198788f5db08d7ce3bc1d0b617176678831a7510825973e357"
+checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
 dependencies = [
  "libc",
 ]
@@ -838,25 +956,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "metal"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e198a0ee42bdbe9ef2c09d0b9426f3b2b47d90d93a4a9b0395c4cea605e92dc0"
-dependencies = [
- "bitflags",
- "block",
- "cocoa 0.20.2",
- "core-graphics 0.19.2",
- "foreign-types",
- "log",
- "objc",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -868,19 +980,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
-]
-
-[[package]]
-name = "ndk"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d868f654c72e75f8687572699cdabe755f03effbb62542768e995d5b8d699d"
-dependencies = [
- "bitflags",
- "jni-sys",
- "ndk-sys 0.2.2",
- "num_enum",
- "thiserror",
 ]
 
 [[package]]
@@ -918,17 +1017,18 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-glue"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71bee8ea72d685477e28bd004cfe1bf99c754d688cd78cad139eae4089484d4"
+checksum = "0434fabdd2c15e0aab768ca31d5b7b333717f03cf02037d5a0a3ff3c278ed67f"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
- "ndk 0.5.0",
+ "ndk 0.7.0",
  "ndk-context",
  "ndk-macro",
- "ndk-sys 0.2.2",
+ "ndk-sys 0.4.0",
+ "once_cell",
+ "parking_lot",
 ]
 
 [[package]]
@@ -943,12 +1043,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "ndk-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1bcdd74c20ad5d95aacd60ef9ba40fdf77f767051040541df557b7a9b2a2121"
 
 [[package]]
 name = "ndk-sys"
@@ -976,7 +1070,7 @@ checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset",
 ]
@@ -989,7 +1083,7 @@ checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset",
 ]
@@ -1001,8 +1095,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1063,16 +1170,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
-]
-
-[[package]]
-name = "objc_exception"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1100,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "os_str_bytes"
@@ -1112,37 +1209,12 @@ checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.3",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1151,7 +1223,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1217,6 +1289,18 @@ name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "png"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -1368,6 +1452,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,7 +1487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1cd5ae51d3f7bf65d7969d579d502168ef578f289452bd8ccc91de28fda20e"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "clipboard-win",
  "fd-lock",
  "libc",
@@ -1413,6 +1506,15 @@ name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
+name = "safe_arch"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ff3d6d9696af502cc3110dacce942840fb06ff4514cad92236ecc455f2ce05"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -1434,6 +1536,18 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sctk-adwaita"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61270629cc6b4d77ec1907db1033d5c2e1a404c412743621981a871dc9c12339"
+dependencies = [
+ "crossfont",
+ "log",
+ "smithay-client-toolkit",
+ "tiny-skia",
+]
 
 [[package]]
 name = "serde"
@@ -1467,10 +1581,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "shaderc"
-version = "0.7.4"
+name = "servo-fontconfig"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e2c757b804157350d8d79d718c756899226016486aab07a11dddf8741111a0"
+checksum = "c7e3e22fe5fd73d04ebf0daa049d3efe3eae55369ce38ab16d07ddd9ac5c217c"
+dependencies = [
+ "libc",
+ "servo-fontconfig-sys",
+]
+
+[[package]]
+name = "servo-fontconfig-sys"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36b879db9892dfa40f95da1c38a835d41634b825fbd8c4c418093d53c24b388"
+dependencies = [
+ "expat-sys",
+ "freetype-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "shaderc"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e6fe602a861622769530a23bc40bfba31adbf186d0c8412e83f5519c5d6bee"
 dependencies = [
  "libc",
  "shaderc-sys",
@@ -1478,22 +1613,13 @@ dependencies = [
 
 [[package]]
 name = "shaderc-sys"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36f3465fce5830d33a58846b9c924f510a1e92bac181834c13b38405efe983b"
+checksum = "3794498651f8173d0afbc0bb8aca45ced111098227e755dde4c0ef2888c8d0bf"
 dependencies = [
  "cmake",
  "libc",
-]
-
-[[package]]
-name = "shared_library"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
-dependencies = [
- "lazy_static",
- "libc",
+ "roxmltree",
 ]
 
 [[package]]
@@ -1509,6 +1635,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
+name = "slotmap"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,9 +1651,9 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a28f16a97fa0e8ce563b2774d1e732dd5d4025d2772c5dba0a41a0f90a29da3"
+checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
 dependencies = [
  "bitflags",
  "calloop",
@@ -1526,7 +1661,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memmap2",
- "nix 0.22.3",
+ "nix 0.24.2",
  "pkg-config",
  "wayland-client",
  "wayland-cursor",
@@ -1598,6 +1733,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642680569bb895b16e4b9d181c60be1ed136fa0c9c7f11d004daf053ba89bf82"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "png",
+ "safe_arch",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c114d32f0c2ee43d585367cb013dfaba967ab9f62b90d9af0d696e955e70fa6c"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1800,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,43 +1813,48 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vk-parse"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f3bfdc05ca5a9f385f50daa1d714b60324b68814b3bae99d797f0952e13e84"
+checksum = "4c6a0bda9bbe6b9e50e6456c80aa8fe4cca3b21e4311a1130c41e4915ec2e32a"
 dependencies = [
  "xml-rs",
 ]
 
 [[package]]
 name = "vulkano"
-version = "0.29.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3663883d6bf6e3d34c891432fe5ce5829ad75f0cc2e43b3d079340385c2d81e0"
+checksum = "eecedd057ea4cd85c0e43ba2ad30e599954bd958c50d0f7849439548cfa573ce"
 dependencies = [
+ "ahash",
  "ash",
  "bytemuck",
+ "core-graphics-types",
  "crossbeam-queue",
  "half",
  "heck",
  "indexmap",
  "lazy_static",
- "parking_lot 0.12.1",
+ "libloading",
+ "objc",
+ "parking_lot",
  "proc-macro2",
  "quote",
  "regex",
  "serde",
  "serde_json",
- "shared_library",
  "smallvec",
+ "thread_local",
  "vk-parse",
 ]
 
 [[package]]
 name = "vulkano-shaders"
-version = "0.29.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a462137ae796894a271b4d8048ef33597a8173e0ae3e4ec54fc72e70c2d1a977"
+checksum = "96bbe0784b21e32661fde8a883bb3f659a473693c9f23bab12c26d7884c15ed0"
 dependencies = [
+ "ahash",
  "heck",
  "proc-macro2",
  "quote",
@@ -1685,14 +1865,13 @@ dependencies = [
 
 [[package]]
 name = "vulkano-win"
-version = "0.29.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba30adc8d7b317e155e43343b6d30195d335df139d168d2ae5ece7837d57e887"
+checksum = "ac1056e3238fe9025628b3de0f401d8c60b7a6dc89e059534568f55fef4e29f7"
 dependencies = [
- "cocoa 0.20.2",
- "metal",
+ "core-graphics-types",
  "objc",
- "raw-window-handle 0.4.3",
+ "raw-window-handle 0.5.0",
  "vulkano",
  "winit",
 ]
@@ -1720,7 +1899,7 @@ version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -1970,35 +2149,44 @@ checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "winit"
-version = "0.26.1"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b43cc931d58b99461188607efd7acb2a093e65fc621f54cad78517a6063e73a"
+checksum = "bb796d6fbd86b2fd896c9471e6f04d39d750076ebe5680a3958f00f5ab97657c"
 dependencies = [
  "bitflags",
- "cocoa 0.24.0",
- "core-foundation 0.9.3",
- "core-graphics 0.22.3",
- "core-video-sys",
+ "cocoa",
+ "core-foundation",
+ "core-graphics",
  "dispatch",
  "instant",
- "lazy_static",
  "libc",
  "log",
  "mio",
- "ndk 0.5.0",
+ "ndk 0.7.0",
  "ndk-glue",
- "ndk-sys 0.2.2",
  "objc",
- "parking_lot 0.11.2",
+ "once_cell",
+ "parking_lot",
  "percent-encoding",
  "raw-window-handle 0.4.3",
+ "raw-window-handle 0.5.0",
+ "sctk-adwaita",
  "smithay-client-toolkit",
  "wasm-bindgen",
  "wayland-client",
  "wayland-protocols",
  "web-sys",
- "winapi",
+ "windows-sys",
  "x11-dl",
+]
+
+[[package]]
+name = "wio"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2026,3 +2214,9 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ psx-core = { path = "./psx-core", version = "*" }
 env_logger = { version = "0.9", default-features = false, features = ["termcolor", "atty"] }
 clap = { version = "3.0.0", features = ["derive"] }
 
-vulkano = "0.29"
-winit = "0.26"
-vulkano-win = "0.29"
+vulkano = "0.32"
+winit = "0.27"
+vulkano-win = "0.32"
 ringbuf = { version = "0.3.1", default-features = false, features = ["alloc"] }
 cpal = { version = "0.14.0", default-features = false }
 

--- a/psx-core/Cargo.toml
+++ b/psx-core/Cargo.toml
@@ -14,8 +14,8 @@ byteorder = "1.4.2"
 log = "0.4.14"
 bitflags = "1.2.1"
 
-vulkano = "0.29"
-vulkano-shaders = "0.29"
+vulkano = "0.32"
+vulkano-shaders = "0.32"
 bytemuck = { version = "1.9.1", features = ["derive"] }
 
 crossbeam = "0.8.1"

--- a/psx-core/src/gpu.rs
+++ b/psx-core/src/gpu.rs
@@ -664,14 +664,6 @@ impl Gpu {
                 // 0x0~0xF retreive info, and the rest are mirrors
                 let info_id = data & 0xF;
 
-                // TODO: we don't need to be empty in our design, but we
-                //       need the old data in some commands, so for now,
-                //       lets make sure we don't have old data, until we
-                //       store it somewhere.
-                assert!(self.gpu_read_sender.is_empty());
-
-                // TODO: some commands read old value of GPUREAD, we can't do that
-                // now. might need to change how we handle GPUREAD in general
                 let result = match info_id {
                     2 => {
                         // Read Texture Window setting GP0(E2h)
@@ -690,7 +682,7 @@ impl Gpu {
                         self.state_snapshot.cached_gp0_e5
                     }
                     6 => {
-                        // return old value of GPUREAD
+                        // TODO: return old value of GPUREAD
                         0
                     }
                     7 => {
@@ -702,7 +694,7 @@ impl Gpu {
                         0
                     }
                     _ => {
-                        // return old value of GPUREAD
+                        // TODO: return old value of GPUREAD
                         0
                     }
                 };

--- a/psx-core/src/gpu/command.rs
+++ b/psx-core/src/gpu/command.rs
@@ -274,6 +274,7 @@ impl Gp0Command for LineCommand {
 struct RectangleCommand {
     textured: bool,
     semi_transparent: bool,
+    texture_blending: bool,
     size_mode: u8,
     size: [f32; 2],
     vertices: Vec<DrawingVertex>,
@@ -291,6 +292,7 @@ impl Gp0Command for RectangleCommand {
             size: [0.0; 2],
             textured: (data0 >> 26) & 1 == 1,
             semi_transparent: (data0 >> 25) & 1 == 1,
+            texture_blending: (data0 >> 24) & 1 == 0, // enabled with 0
             vertices: vec![DrawingVertex::new_with_color(data0); 6],
             texture_params: DrawingTextureParams::default(),
             current_input_state: 0,
@@ -403,7 +405,7 @@ impl Gp0Command for RectangleCommand {
             vertices: self.vertices,
             texture_params: self.texture_params,
             textured: self.textured,
-            texture_blending: false,
+            texture_blending: self.texture_blending,
             semi_transparent: self.semi_transparent,
             state_snapshot: state_snapshot.clone(),
         })

--- a/psx-core/src/gpu/gpu_backend.rs
+++ b/psx-core/src/gpu/gpu_backend.rs
@@ -1,12 +1,15 @@
 use crate::gpu::GpuStat;
 
-use super::{gpu_context::GpuContext, BackendCommand};
+use super::{
+    gpu_context::{GpuContext, GpuSharedState},
+    BackendCommand,
+};
 use crossbeam::{
     atomic::AtomicCell,
     channel::{Receiver, Sender},
 };
 use std::{
-    sync::Arc,
+    sync::{Arc, Mutex},
     thread::{self, JoinHandle},
 };
 use vulkano::{
@@ -25,6 +28,7 @@ impl GpuBackend {
         device: Arc<Device>,
         queue: Arc<Queue>,
         gpu_stat: Arc<AtomicCell<GpuStat>>,
+        shared_state: Arc<Mutex<GpuSharedState>>,
         gpu_read_sender: Sender<u32>,
         gpu_backend_receiver: Receiver<BackendCommand>,
         gpu_front_image_sender: Sender<Arc<StorageImage>>,
@@ -35,6 +39,7 @@ impl GpuBackend {
                     device,
                     queue,
                     gpu_stat,
+                    shared_state,
                     gpu_read_sender,
                     gpu_front_image_sender,
                 ),
@@ -47,7 +52,6 @@ impl GpuBackend {
     fn run(mut self) {
         loop {
             match self.gpu_backend_receiver.recv() {
-                Ok(BackendCommand::Gp1Write(data)) => self.run_gp1_command(data),
                 Ok(BackendCommand::BlitFront(full_vram)) => {
                     self.gpu_context.blit_to_front(full_vram);
                 }
@@ -57,129 +61,6 @@ impl GpuBackend {
                 }
                 Err(_) => {}
             }
-        }
-    }
-}
-
-impl GpuBackend {
-    fn run_gp1_command(&mut self, data: u32) {
-        let cmd = data >> 24;
-        log::info!("gp1 command {:02X} data: {:08X}", cmd, data);
-        match cmd {
-            0x00 => {
-                // handled by frontend
-                unreachable!();
-            }
-            0x01 => {
-                // handled by frontend
-                unreachable!();
-            }
-            0x02 => {
-                // handled by frontend
-                unreachable!();
-            }
-            0x03 => {
-                // handled by frontend
-                unreachable!();
-            }
-            0x04 => {
-                // handled by frontend
-                unreachable!();
-            }
-            0x05 => {
-                // Vram Start of Display area
-
-                let x = data & 0x3ff;
-                let y = (data >> 10) & 0x1ff;
-
-                self.gpu_context.vram_display_area_start = (x, y);
-                log::info!(
-                    "vram display start area {:?}",
-                    self.gpu_context.vram_display_area_start
-                );
-            }
-            0x06 => {
-                // Screen Horizontal Display range
-                let x1 = data & 0xfff;
-                let x2 = (data >> 12) & 0xfff;
-
-                self.gpu_context.display_horizontal_range = (x1, x2);
-                log::info!(
-                    "display horizontal range {:?}",
-                    self.gpu_context.display_horizontal_range
-                );
-            }
-            0x07 => {
-                // Screen Vertical Display range
-                let y1 = data & 0x1ff;
-                let y2 = (data >> 10) & 0x1ff;
-
-                self.gpu_context.display_vertical_range = (y1, y2);
-                log::info!(
-                    "display vertical range {:?}",
-                    self.gpu_context.display_vertical_range
-                );
-            }
-            0x08 => {
-                // handled by frontend
-                unreachable!();
-            }
-            0x09 => {
-                // Allow texture disable
-                self.gpu_context.allow_texture_disable = data & 1 == 1;
-            }
-            0x10 => {
-                // GPU info
-
-                // 0x0~0xF retreive info, and the rest are mirrors
-                let info_id = data & 0xF;
-
-                // TODO: we don't need to be empty in our design, but we
-                //       need the old data in some commands, so for now,
-                //       lets make sure we don't have old data, until we
-                //       store it somewhere.
-                //assert!(self.gpu_read_sender.is_empty());
-
-                // TODO: some commands read old value of GPUREAD, we can't do that
-                // now. might need to change how we handle GPUREAD in general
-                let result = match info_id {
-                    2 => {
-                        // Read Texture Window setting GP0(E2h)
-                        self.gpu_context.cached_gp0_e2
-                    }
-                    3 => {
-                        // Read Draw area top left GP0(E3h)
-                        self.gpu_context.cached_gp0_e3
-                    }
-                    4 => {
-                        // Read Draw area bottom right GP0(E4h)
-                        self.gpu_context.cached_gp0_e4
-                    }
-                    5 => {
-                        // Read Draw offset GP0(E5h)
-                        self.gpu_context.cached_gp0_e5
-                    }
-                    6 => {
-                        // return old value of GPUREAD
-                        0
-                    }
-                    7 => {
-                        // GPU type
-                        2
-                    }
-                    8 => {
-                        // unknown
-                        0
-                    }
-                    _ => {
-                        // return old value of GPUREAD
-                        0
-                    }
-                };
-
-                self.gpu_context.send_to_gpu_read(result);
-            }
-            _ => todo!("gp1 command {:02X}", cmd),
         }
     }
 }

--- a/psx-core/src/gpu/gpu_context.rs
+++ b/psx-core/src/gpu/gpu_context.rs
@@ -80,7 +80,7 @@ pub fn vertex_position_from_u32(position: u32) -> [f32; 2] {
 pub struct DrawingVertex {
     position: [f32; 2],
     color: [f32; 3],
-    tex_coord: [u32; 2],
+    tex_coord: [i32; 2],
 }
 
 impl DrawingVertex {
@@ -95,12 +95,12 @@ impl DrawingVertex {
     }
 
     #[inline]
-    pub fn tex_coord(&mut self) -> [u32; 2] {
+    pub fn tex_coord(&mut self) -> [i32; 2] {
         self.tex_coord
     }
 
     #[inline]
-    pub fn set_tex_coord(&mut self, tex_coord: [u32; 2]) {
+    pub fn set_tex_coord(&mut self, tex_coord: [i32; 2]) {
         self.tex_coord = tex_coord;
     }
 
@@ -127,7 +127,7 @@ impl DrawingVertex {
 
     #[inline]
     pub fn tex_coord_from_u32(&mut self, tex_coord: u32) {
-        self.tex_coord = [(tex_coord & 0xFF), ((tex_coord >> 8) & 0xFF)];
+        self.tex_coord = [(tex_coord & 0xFF) as i32, ((tex_coord >> 8) & 0xFF) as i32];
     }
 }
 
@@ -143,7 +143,7 @@ impl DrawingVertex {
 struct DrawingVertexFull {
     position: [f32; 2],
     color: [f32; 3],
-    tex_coord: [u32; 2],
+    tex_coord: [i32; 2],
 
     clut_base: [u32; 2],
     tex_page_base: [u32; 2],

--- a/psx-core/src/gpu/gpu_context.rs
+++ b/psx-core/src/gpu/gpu_context.rs
@@ -149,7 +149,6 @@ struct DrawingVertexFull {
     tex_page_base: [u32; 2],
     semi_transparency_mode: u32, // u8
     tex_page_color_mode: u32,    // u8
-    texture_flip: [u32; 2],      // (bool, bool)
 
     semi_transparent: u32,   // bool
     dither_enabled: u32,     // bool
@@ -166,7 +165,6 @@ vulkano::impl_vertex!(
     tex_page_base,
     semi_transparency_mode,
     tex_page_color_mode,
-    texture_flip,
     semi_transparent,
     dither_enabled,
     is_textured,
@@ -180,7 +178,6 @@ pub struct DrawingTextureParams {
     pub semi_transparency_mode: u8,
     pub tex_page_color_mode: u8,
     pub texture_disable: bool,
-    pub texture_flip: (bool, bool),
 }
 
 impl DrawingTextureParams {
@@ -212,11 +209,6 @@ impl DrawingTextureParams {
         let x = param & 0x3F;
         let y = (param >> 6) & 0x1FF;
         self.clut_base = [x * 16, y];
-    }
-
-    #[inline]
-    pub fn set_texture_flip(&mut self, flip: (bool, bool)) {
-        self.texture_flip = flip;
     }
 }
 
@@ -1131,10 +1123,6 @@ impl GpuContext {
             tex_page_base: texture_params.tex_page_base,
             semi_transparency_mode: semi_transparency_mode as u32,
             tex_page_color_mode: texture_params.tex_page_color_mode as u32,
-            texture_flip: [
-                texture_params.texture_flip.0 as u32,
-                texture_params.texture_flip.1 as u32,
-            ],
             semi_transparent: semi_transparent as u32,
             dither_enabled: gpu_stat.dither_enabled() as u32,
             is_textured: textured as u32,

--- a/psx-core/src/gpu/gpu_context.rs
+++ b/psx-core/src/gpu/gpu_context.rs
@@ -250,7 +250,6 @@ struct BufferedDrawsState {
 
 pub struct GpuContext {
     pub(super) gpu_front_image_sender: Sender<Arc<StorageImage>>,
-    gpu_read_sender: Sender<u32>,
 
     pub(super) device: Arc<Device>,
     queue: Arc<Queue>,
@@ -284,7 +283,6 @@ impl GpuContext {
     pub(super) fn new(
         device: Arc<Device>,
         queue: Arc<Queue>,
-        gpu_read_sender: Sender<u32>,
         gpu_front_image_sender: Sender<Arc<StorageImage>>,
     ) -> Self {
         let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
@@ -467,7 +465,6 @@ impl GpuContext {
         .unwrap();
 
         Self {
-            gpu_read_sender,
             gpu_front_image_sender,
 
             device,
@@ -498,10 +495,6 @@ impl GpuContext {
             command_builder,
             buffered_commands: 0,
         }
-    }
-
-    pub(super) fn send_to_gpu_read(&self, value: u32) {
-        self.gpu_read_sender.send(value).unwrap();
     }
 }
 

--- a/psx-core/src/gpu/gpu_context.rs
+++ b/psx-core/src/gpu/gpu_context.rs
@@ -890,23 +890,12 @@ impl GpuContext {
     }
 
     fn new_command_buffer_builder(&mut self) -> AutoCommandBufferBuilder<PrimaryAutoCommandBuffer> {
-        let mut builder = AutoCommandBufferBuilder::primary(
+        let builder = AutoCommandBufferBuilder::primary(
             &self.command_buffer_allocator,
             self.queue.queue_family_index(),
             CommandBufferUsage::OneTimeSubmit,
         )
         .unwrap();
-
-        // copy to the back buffer
-        // NOTE: For some reason, removing this results in conflict error from vulkano
-        //       not sure, if there is a bug with the conflict checker or not, but
-        //       for now, we add this command in the beginning before binding the image as texture.
-        builder
-            .copy_image(CopyImageInfo::images(
-                self.render_image.clone(),
-                self.render_image_back_image.clone(),
-            ))
-            .unwrap();
 
         builder
     }

--- a/psx-core/src/gpu/shaders/fragment.glsl
+++ b/psx-core/src/gpu/shaders/fragment.glsl
@@ -106,11 +106,13 @@ void main() {
             divider = 1;
         }
 
-        float x = v_tex_coord.x / divider;
-        float y = v_tex_coord.y;
+        // texture flip and texture repeat support
+        // flipped textures, will have decrement in number
+        // and might flip to negative as well, we can handle that by mod
+        vec2 norm_coord = mod(v_tex_coord, 255);
 
-        uint ux = uint(x);
-        uint uy = uint(y);
+        float x = norm_coord.x / divider;
+        float y = norm_coord.y;
 
         vec4 color_value = fetch_color_from_texture_float(vec2(v_tex_page_base) + vec2(x, y));
 
@@ -119,7 +121,7 @@ void main() {
             uint color_u16 = u16_from_color_with_alpha(color_value);
 
             uint mask = 0xFFFFu >> (16u - (16u / divider));
-            uint clut_index_shift = (uint(floor(v_tex_coord.x)) % divider) * (16u / divider);
+            uint clut_index_shift = (uint(x) % divider) * (16u / divider);
             uint clut_index = (color_u16 >> clut_index_shift) & mask;
 
             color_value = fetch_color_from_texture(v_clut_base + uvec2(clut_index, 0));

--- a/psx-core/src/gpu/shaders/fragment.glsl
+++ b/psx-core/src/gpu/shaders/fragment.glsl
@@ -7,11 +7,10 @@ layout(location = 2)  flat in uvec2 v_clut_base;
 layout(location = 3)  flat in uvec2 v_tex_page_base;
 layout(location = 4)  flat in uint  v_semi_transparency_mode;
 layout(location = 5)  flat in uint  v_tex_page_color_mode;
-layout(location = 6)  flat in uvec2 v_texture_flip;
-layout(location = 7)  flat in uint  v_semi_transparent;
-layout(location = 8)  flat in uint  v_dither_enabled;
-layout(location = 9)  flat in uint  v_is_textured;
-layout(location = 10) flat in uint  v_is_texture_blended;
+layout(location = 6)  flat in uint  v_semi_transparent;
+layout(location = 7)  flat in uint  v_dither_enabled;
+layout(location = 8)  flat in uint  v_is_textured;
+layout(location = 9) flat in uint  v_is_texture_blended;
 
 layout(location = 0) out vec4 f_color;
 
@@ -112,14 +111,6 @@ void main() {
 
         uint ux = uint(x);
         uint uy = uint(y);
-
-        // texture flips
-        if (v_texture_flip.x == 1) {
-            x = (255 / divider) - x;
-        }
-        if (v_texture_flip.y == 1) {
-            y = 255 - y;
-        }
 
         vec4 color_value = fetch_color_from_texture_float(vec2(v_tex_page_base) + vec2(x, y));
 

--- a/psx-core/src/gpu/shaders/fragment.glsl
+++ b/psx-core/src/gpu/shaders/fragment.glsl
@@ -121,7 +121,7 @@ void main() {
             uint color_u16 = u16_from_color_with_alpha(color_value);
 
             uint mask = 0xFFFFu >> (16u - (16u / divider));
-            uint clut_index_shift = (uint(x) % divider) * (16u / divider);
+            uint clut_index_shift = (uint(norm_coord.x) % divider) * (16u / divider);
             uint clut_index = (color_u16 >> clut_index_shift) & mask;
 
             color_value = fetch_color_from_texture(v_clut_base + uvec2(clut_index, 0));

--- a/psx-core/src/gpu/shaders/vertex.glsl
+++ b/psx-core/src/gpu/shaders/vertex.glsl
@@ -2,7 +2,7 @@
 
 layout(location = 0)  in vec2 position;
 layout(location = 1)  in vec3  color;
-layout(location = 2)  in uvec2 tex_coord;
+layout(location = 2)  in ivec2 tex_coord;
 
 layout(location = 3)  in uvec2 clut_base;
 layout(location = 4)  in uvec2 tex_page_base;

--- a/psx-core/src/gpu/shaders/vertex.glsl
+++ b/psx-core/src/gpu/shaders/vertex.glsl
@@ -8,11 +8,10 @@ layout(location = 3)  in uvec2 clut_base;
 layout(location = 4)  in uvec2 tex_page_base;
 layout(location = 5)  in uint  semi_transparency_mode;
 layout(location = 6)  in uint  tex_page_color_mode;
-layout(location = 7)  in uvec2 texture_flip;
-layout(location = 8)  in uint  semi_transparent;
-layout(location = 9)  in uint  dither_enabled;
-layout(location = 10) in uint  is_textured;
-layout(location = 11) in uint  is_texture_blended;
+layout(location = 7)  in uint  semi_transparent;
+layout(location = 8)  in uint  dither_enabled;
+layout(location = 9)  in uint  is_textured;
+layout(location = 10) in uint  is_texture_blended;
 
 
 layout(location = 0)  out vec3  v_color;
@@ -22,11 +21,10 @@ layout(location = 2)  flat out uvec2 v_clut_base;
 layout(location = 3)  flat out uvec2 v_tex_page_base;
 layout(location = 4)  flat out uint  v_semi_transparency_mode;
 layout(location = 5)  flat out uint  v_tex_page_color_mode;
-layout(location = 6)  flat out uvec2 v_texture_flip;
-layout(location = 7)  flat out uint  v_semi_transparent;
-layout(location = 8)  flat out uint  v_dither_enabled;
-layout(location = 9)  flat out uint  v_is_textured;
-layout(location = 10) flat out uint  v_is_texture_blended;
+layout(location = 6)  flat out uint  v_semi_transparent;
+layout(location = 7)  flat out uint  v_dither_enabled;
+layout(location = 8)  flat out uint  v_is_textured;
+layout(location = 9) flat out uint  v_is_texture_blended;
 
 layout(push_constant) uniform PushConstantData {
     ivec2 offset;
@@ -45,7 +43,6 @@ void main() {
     v_tex_page_base          = tex_page_base;
     v_semi_transparency_mode = semi_transparency_mode;
     v_tex_page_color_mode    = tex_page_color_mode;
-    v_texture_flip           = texture_flip;
     v_semi_transparent       = semi_transparent;
     v_dither_enabled         = dither_enabled;
     v_is_textured            = is_textured;

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,6 +315,18 @@ impl VkDisplay {
             DisplayType::Headless => {}
         }
     }
+
+    fn toggle_full_vram_display(&mut self) {
+        match self.display_type {
+            DisplayType::Windowed {
+                ref mut full_vram_display,
+                ..
+            } => {
+                *full_vram_display = !*full_vram_display;
+            }
+            DisplayType::Headless => {}
+        }
+    }
 }
 
 #[derive(Parser, Debug)]
@@ -328,7 +340,7 @@ struct PsxEmuArgs {
     /// logs to the console, which can be useful for testing)
     #[clap(short, long)]
     windowed: bool,
-    /// Display the full vram
+    /// Initial value for `display full vram`, can be changed later with [V] key
     #[clap(short, long)]
     vram: bool,
     /// Play audio
@@ -409,6 +421,7 @@ fn main() {
                         match input.virtual_keycode {
                             // Pause CPU and enable debug
                             Some(VirtualKeyCode::Slash) => psx.pause_cpu(),
+                            Some(VirtualKeyCode::V) => display.toggle_full_vram_display(),
                             _ => {}
                         }
                     }


### PR DESCRIPTION
- updated vulkano to `0.32`
- Added support for wrapping vram_read/write
- several performance boosts
- Handled commands functionality except rendering in the main cpu thread. This allows for accurate emulation, as GPU_STAT and other flags would be associated with the command sent to the backend (rendering thread).
- Added handling for interrupting the command `CpuToVramBlit`
- Added ability to switch to full vram view in runtime with keyboard key `[V]`
- Several fixes to `Rectangle` rendering
    - Added `texture_blending`
    - Fixed texture flip and added support for texture repeat
- Several fixes in texture handling
- remove the need to copy to `back_image` for every command builder