### PR TITLE
Gpu texwindow

### DIFF
--- a/psx-core/src/gpu/gpu_context.rs
+++ b/psx-core/src/gpu/gpu_context.rs
@@ -150,6 +150,12 @@ struct DrawingVertexFull {
     tex_info: [u32; 4],
 
     /// group multiple data into one array
+    /// tex_window_mask: [u32; 2],
+    /// tex_window_offset: [u32; 2],
+    #[format(R32G32B32A32_UINT)]
+    tex_window: [u32; 4],
+
+    /// group multiple data into one array
     ///
     /// semi_transparency_mode: u32,
     /// tex_page_color_mode: u32,
@@ -166,6 +172,8 @@ impl DrawingVertexFull {
     fn new(
         v: &DrawingVertex,
         texture_params: &DrawingTextureParams,
+        texture_window_mask: (u32, u32),
+        texture_window_offset: (u32, u32),
         semi_transparency_mode: u8,
         semi_transparent: bool,
         dither_enabled: bool,
@@ -185,6 +193,12 @@ impl DrawingVertexFull {
                 texture_params.clut_base[1],
                 texture_params.tex_page_base[0],
                 texture_params.tex_page_base[1],
+            ],
+            tex_window: [
+                texture_window_mask.0,
+                texture_window_mask.1,
+                texture_window_offset.0,
+                texture_window_offset.1,
             ],
             extra_draw_state: [
                 semi_transparency_mode as u32,
@@ -1099,6 +1113,9 @@ impl GpuContext {
             return;
         }
 
+        let texture_window_mask = state_snapshot.texture_window_mask;
+        let texture_window_offset = state_snapshot.texture_window_offset;
+
         drop(state_snapshot);
 
         let mut semi_transparency_mode = if textured {
@@ -1152,6 +1169,8 @@ impl GpuContext {
             DrawingVertexFull::new(
                 v,
                 &texture_params,
+                texture_window_mask,
+                texture_window_offset,
                 semi_transparency_mode,
                 semi_transparent,
                 gpu_stat.dither_enabled(),

--- a/psx-core/src/gpu/gpu_context.rs
+++ b/psx-core/src/gpu/gpu_context.rs
@@ -143,21 +143,23 @@ struct DrawingVertexFull {
     #[format(R32G32_SINT)]
     tex_coord: [i32; 2],
 
-    #[format(R32G32_UINT)]
-    clut_base: [u32; 2],
-    #[format(R32G32_UINT)]
-    tex_page_base: [u32; 2],
-    #[format(R32_UINT)]
-    semi_transparency_mode: u32, // u8
-    #[format(R32_UINT)]
-    tex_page_color_mode: u32, // u8
+    /// group multiple data into one array
+    /// clut_base: [u32; 2],
+    /// tex_page_base: [u32; 2],
+    #[format(R32G32B32A32_UINT)]
+    tex_info: [u32; 4],
 
-    /// bit 0: semi_transparent
-    /// bit 1: dither_enabled
-    /// bit 2: is_textured
-    /// bit 3: is_texture_blended
-    #[format(R32_UINT)]
-    bool_flags: u32,
+    /// group multiple data into one array
+    ///
+    /// semi_transparency_mode: u32,
+    /// tex_page_color_mode: u32,
+    /// bool_flags: u32,
+    ///  bit 0: semi_transparent
+    ///  bit 1: dither_enabled
+    ///  bit 2: is_textured
+    ///  bit 3: is_texture_blended
+    #[format(R32G32B32_UINT)]
+    extra_draw_state: [u32; 3],
 }
 
 impl DrawingVertexFull {
@@ -178,11 +180,17 @@ impl DrawingVertexFull {
             position: v.position,
             color: v.color,
             tex_coord: v.tex_coord,
-            clut_base: texture_params.clut_base,
-            tex_page_base: texture_params.tex_page_base,
-            semi_transparency_mode: semi_transparency_mode as u32,
-            tex_page_color_mode: texture_params.tex_page_color_mode as u32,
-            bool_flags,
+            tex_info: [
+                texture_params.clut_base[0],
+                texture_params.clut_base[1],
+                texture_params.tex_page_base[0],
+                texture_params.tex_page_base[1],
+            ],
+            extra_draw_state: [
+                semi_transparency_mode as u32,
+                texture_params.tex_page_color_mode as u32,
+                bool_flags,
+            ],
         }
     }
 }

--- a/psx-core/src/gpu/shaders/vertex.glsl
+++ b/psx-core/src/gpu/shaders/vertex.glsl
@@ -1,6 +1,6 @@
 #version 450
 
-layout(location = 0)  in vec2 position;
+layout(location = 0)  in vec2  position;
 layout(location = 1)  in vec3  color;
 layout(location = 2)  in ivec2 tex_coord;
 
@@ -8,10 +8,7 @@ layout(location = 3)  in uvec2 clut_base;
 layout(location = 4)  in uvec2 tex_page_base;
 layout(location = 5)  in uint  semi_transparency_mode;
 layout(location = 6)  in uint  tex_page_color_mode;
-layout(location = 7)  in uint  semi_transparent;
-layout(location = 8)  in uint  dither_enabled;
-layout(location = 9)  in uint  is_textured;
-layout(location = 10) in uint  is_texture_blended;
+layout(location = 7)  in uint  bool_flags;
 
 
 layout(location = 0)  out vec3  v_color;
@@ -21,10 +18,7 @@ layout(location = 2)  flat out uvec2 v_clut_base;
 layout(location = 3)  flat out uvec2 v_tex_page_base;
 layout(location = 4)  flat out uint  v_semi_transparency_mode;
 layout(location = 5)  flat out uint  v_tex_page_color_mode;
-layout(location = 6)  flat out uint  v_semi_transparent;
-layout(location = 7)  flat out uint  v_dither_enabled;
-layout(location = 8)  flat out uint  v_is_textured;
-layout(location = 9) flat out uint  v_is_texture_blended;
+layout(location = 6)  flat out uint  v_bool_flags;
 
 layout(push_constant) uniform PushConstantData {
     ivec2 offset;
@@ -43,8 +37,5 @@ void main() {
     v_tex_page_base          = tex_page_base;
     v_semi_transparency_mode = semi_transparency_mode;
     v_tex_page_color_mode    = tex_page_color_mode;
-    v_semi_transparent       = semi_transparent;
-    v_dither_enabled         = dither_enabled;
-    v_is_textured            = is_textured;
-    v_is_texture_blended     = is_texture_blended;
+    v_bool_flags             = bool_flags;
 }

--- a/psx-core/src/gpu/shaders/vertex.glsl
+++ b/psx-core/src/gpu/shaders/vertex.glsl
@@ -4,21 +4,15 @@ layout(location = 0)  in vec2  position;
 layout(location = 1)  in vec3  color;
 layout(location = 2)  in ivec2 tex_coord;
 
-layout(location = 3)  in uvec2 clut_base;
-layout(location = 4)  in uvec2 tex_page_base;
-layout(location = 5)  in uint  semi_transparency_mode;
-layout(location = 6)  in uint  tex_page_color_mode;
-layout(location = 7)  in uint  bool_flags;
+layout(location = 3)  in uvec4 tex_info;
+layout(location = 4)  in uvec3 extra_draw_state;
 
 
 layout(location = 0)  out vec3  v_color;
 layout(location = 1)  out vec2  v_tex_coord;
 
-layout(location = 2)  flat out uvec2 v_clut_base;
-layout(location = 3)  flat out uvec2 v_tex_page_base;
-layout(location = 4)  flat out uint  v_semi_transparency_mode;
-layout(location = 5)  flat out uint  v_tex_page_color_mode;
-layout(location = 6)  flat out uint  v_bool_flags;
+layout(location = 2)  flat out uvec4 v_tex_info;
+layout(location = 3)  flat out uvec3 v_extra_draw_state;
 
 layout(push_constant) uniform PushConstantData {
     ivec2 offset;
@@ -33,9 +27,6 @@ void main() {
     v_color = color;
     v_tex_coord = vec2(tex_coord);
 
-    v_clut_base              = clut_base;
-    v_tex_page_base          = tex_page_base;
-    v_semi_transparency_mode = semi_transparency_mode;
-    v_tex_page_color_mode    = tex_page_color_mode;
-    v_bool_flags             = bool_flags;
+    v_tex_info               = tex_info;
+    v_extra_draw_state       = extra_draw_state;
 }

--- a/psx-core/src/gpu/shaders/vertex.glsl
+++ b/psx-core/src/gpu/shaders/vertex.glsl
@@ -5,14 +5,16 @@ layout(location = 1)  in vec3  color;
 layout(location = 2)  in ivec2 tex_coord;
 
 layout(location = 3)  in uvec4 tex_info;
-layout(location = 4)  in uvec3 extra_draw_state;
+layout(location = 4)  in uvec4 tex_window;
+layout(location = 5)  in uvec3 extra_draw_state;
 
 
 layout(location = 0)  out vec3  v_color;
 layout(location = 1)  out vec2  v_tex_coord;
 
 layout(location = 2)  flat out uvec4 v_tex_info;
-layout(location = 3)  flat out uvec3 v_extra_draw_state;
+layout(location = 3)  flat out uvec4 v_tex_window;
+layout(location = 4)  flat out uvec3 v_extra_draw_state;
 
 layout(push_constant) uniform PushConstantData {
     ivec2 offset;
@@ -28,5 +30,6 @@ void main() {
     v_tex_coord = vec2(tex_coord);
 
     v_tex_info               = tex_info;
+    v_tex_window             = tex_window;
     v_extra_draw_state       = extra_draw_state;
 }


### PR DESCRIPTION
General improvements to the shader handling in the GPU.

and

Implement texture window setting support.

This allows rendering textures to be from a specific window in the texpage. this allow to easily render large textures by repeating a small region without the need of filling the vram with a huge texpage filled with repeated pattern.

Before this, some games were having weird texturing, example:

BEFORE:
![image](https://user-images.githubusercontent.com/26300843/236498682-d10b864c-15ce-4448-a5fe-d35af3bf527b.png)

AFTER:
![image](https://user-images.githubusercontent.com/26300843/236499176-1b7235ab-d082-468c-b3e1-9274b565a943.png)

The window is inside the small square that is under "1 2" in the BEFORE image, it does multiple texture window command based on the next portion it wants.

This appears to be used by tile based games, like RPGs and these kind of stuff where one texpage has a lot of sprites/tiles.
