### PR TITLE
Added support for headless mode and better FPS handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -451,10 +451,9 @@ struct PsxEmuArgs {
     bios: PathBuf,
     /// The disk/exe file to run, without this, it will run the bios only
     disk_file: Option<PathBuf>,
-    /// Turn on window display (without this, it will only print the
-    /// logs to the console, which can be useful for testing)
-    #[arg(short, long)]
-    windowed: bool,
+    /// Turn off window display and run in headless mode
+    #[arg(short = 'e', long)]
+    headless: bool,
     /// Initial value for `display full vram`, can be changed later with [V] key
     #[arg(short, long)]
     vram: bool,
@@ -474,10 +473,10 @@ fn main() {
 
     let args = PsxEmuArgs::parse();
 
-    let display = if args.windowed {
-        VkDisplay::windowed(args.vram)
-    } else {
+    let display = if args.headless {
         VkDisplay::headless()
+    } else {
+        VkDisplay::windowed(args.vram)
     };
 
     let mut psx = Psx::new(


### PR DESCRIPTION
There was an issue on 144hz displays, where it wasn't reaching 60 FPS, because we were checking for a strict 16.6ms time for each frame, and 144 is not divisible by 60 so thats why it was not reaching it.

Fixed by predicting if we are going to be in the time of a PSX frame in the middle of 2 144hz frames and then rendering at that time, and keeping an offset so we don't exceed 60FPS.

Another issue is that on ssh environment or where xorg/wayland is not available, we were generating error because `EventLoop` require these to be available. Even though we don't need them to emulate.
Currently headless doesn't do anything useful but just runs, which is fine for now.

Added `headless` (`-e`) flag, to enable headless mode, which is disabled now by default.