### PR TITLE
Fix small issues in the SPU and GPU

### DIFF
--- a/psx-core/src/gpu/gpu_context.rs
+++ b/psx-core/src/gpu/gpu_context.rs
@@ -1283,7 +1283,7 @@ impl GpuContext {
                 front_image.clone(),
                 topleft,
                 size,
-                gpu_stat.is_24bit_color_depth(),
+                !full_vram && gpu_stat.is_24bit_color_depth(),
                 self.gpu_future.take().unwrap(),
             )
             .then_signal_fence_and_flush()


### PR DESCRIPTION
- Some games were crashing the SPU because they are doing some cleanup for all registers at startup.
- Always view `full_vram` in 15 bit mode, to make it easier to debug.