### PR TITLE
Let 3rd parties be able to emulate MIPS processors

### DIFF
--- a/trapezoid-core/src/cpu.rs
+++ b/trapezoid-core/src/cpu.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "debugger")]
 mod debugger;
-mod instruction;
+pub mod instruction;
 mod instructions_table;
 mod register;
 

--- a/trapezoid-core/src/cpu/instruction.rs
+++ b/trapezoid-core/src/cpu/instruction.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use super::instructions_table::{PRIMARY_OPCODES, SECONDARY_OPCODES};
 use super::RegisterType;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Opcode {
     #[doc(hidden)]
     /// This is a special opcode used when parsing the instruction,


### PR DESCRIPTION
This pull request is being developed in tandem with [MIPS](https://github.com/omarandlorraine/strop/pull/96), a pull request adding MIPS support to strop.

I anticipate that the biggest changes here are that some things will need to be made public.