### PR TITLE
Improve docs and public API for `trapezoid` `Cpu` standalone usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,6 +1956,7 @@ version = "0.2.0"
 dependencies = [
  "bitflags 2.9.0",
  "byteorder",
+ "env_logger",
  "log",
  "vulkano",
  "vulkano-shaders",

--- a/trapezoid-core/Cargo.toml
+++ b/trapezoid-core/Cargo.toml
@@ -17,6 +17,7 @@ default = ["vulkan"]
 # Enable `vulkan` backend rendering, and also correct GPU emulation,
 # without this, GPU emulation will be not working as expected
 vulkan = ["vulkano", "vulkano-shaders"]
+# Enable support for CPU debugger API
 debugger = []
 
 [dependencies]
@@ -27,3 +28,7 @@ bitflags = "2.9"
 vulkano = { version = "0.35", optional = true }
 vulkano-shaders = { version = "0.35", optional = true }
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+rustc-args = ["--cfg", "docsrs"]

--- a/trapezoid-core/Cargo.toml
+++ b/trapezoid-core/Cargo.toml
@@ -28,6 +28,14 @@ bitflags = "2.9"
 vulkano = { version = "0.35", optional = true }
 vulkano-shaders = { version = "0.35", optional = true }
 
+[dev-dependencies]
+env_logger = { version = "0.11", default-features = false, features = ["auto-color"] }
+
+[[example]]
+name = "trapezoid_cpu"
+path = "examples/trapezoid_cpu.rs"
+required-features = []
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/trapezoid-core/examples/trapezoid_cpu.rs
+++ b/trapezoid-core/examples/trapezoid_cpu.rs
@@ -1,0 +1,193 @@
+//! This is an example of how to use the `Cpu` for standalone emulation.
+//!
+//! Here, we have a custom memory Bus that implements our reads and writes.
+//!
+//! We have made some specific "hardware registers" to interact with the outside world.
+//!
+//! We have set `0x0` to be the exit register, and `0x4` to be the write character register.
+//!
+//! Beside that, everything is in the memory at `0xBFC00000..=0xBFC0FFFF`. because that's where the
+//! PC start and that's the reset vector location. We can jump anywhere from there.
+//!
+//! Though, for now, the CPU won't crash or interrupt if it tries to read unsupported locations.
+//! It will just be logged, so that it doesn't affect the PSX operations
+//! (make sure you have logger setup if you want to get notified).
+//!
+//! The simple code is compiled below, view the commented code for more details.
+//!
+
+use trapezoid_core::cpu::{BusLine, Cpu, CpuBusProvider};
+
+struct Bus {
+    kseg1: [u8; 0x10000],
+    is_done: bool,
+}
+
+impl BusLine for Bus {
+    // just maps the kseg1 memory to the CPU
+    fn read_u32(&mut self, addr: u32) -> Result<u32, String> {
+        match addr {
+            0xBFC00000..=0xBFC0FFFF => {
+                let offset = addr - 0xBFC00000;
+                let word = u32::from_le_bytes([
+                    self.kseg1[offset as usize],
+                    self.kseg1[(offset + 1) as usize],
+                    self.kseg1[(offset + 2) as usize],
+                    self.kseg1[(offset + 3) as usize],
+                ]);
+                Ok(word)
+            }
+            _ => Err(format!("Unimplemented read at address {:08X}", addr)),
+        }
+    }
+
+    // just maps the kseg1 memory to the CPU, needed to read the string data
+    fn read_u8(&mut self, addr: u32) -> Result<u8, String> {
+        match addr {
+            0xBFC00000..=0xBFC0FFFF => {
+                let offset = addr - 0xBFC00000;
+                Ok(self.kseg1[offset as usize])
+            }
+            _ => Err(format!("Unimplemented read at address {:08X}", addr)),
+        }
+    }
+
+    // Ability to write to the stack location, here we allow whole kseg1, but can be limited as
+    // needed
+    fn write_u32(&mut self, addr: u32, data: u32) -> Result<(), String> {
+        match addr {
+            0xBFC00000..=0xBFC0FFFF => {
+                let offset = addr - 0xBFC00000;
+                self.kseg1[offset as usize] = data as u8;
+                self.kseg1[(offset + 1) as usize] = (data >> 8) as u8;
+                self.kseg1[(offset + 2) as usize] = (data >> 16) as u8;
+                self.kseg1[(offset + 3) as usize] = (data >> 24) as u8;
+                Ok(())
+            }
+            _ => Err(format!("Unimplemented write at address {:08X}", addr)),
+        }
+    }
+
+    // support our custom registers
+    fn write_u8(&mut self, addr: u32, data: u8) -> Result<(), String> {
+        match addr {
+            // exit
+            0x0 => {
+                println!("Write to address 0x0: {:08X}, exiting", data);
+                self.is_done = data != 0x0;
+                Ok(())
+            }
+            // write a character
+            0x4 => {
+                print!("{}", data as char);
+                Ok(())
+            }
+            _ => Err(format!("Unimplemented write at address {:08X}", addr)),
+        }
+    }
+}
+
+// Not used for now, we don't have interrupts handling from the hardware
+// If we do, when `pending_interrupts` returns true, the CPU will jump to the interrupt vector with
+// cause `Interrupt` (not available for public API), but the interrupt vector is
+// `0xBFC00180` or `0x80000080`.
+impl CpuBusProvider for Bus {
+    fn pending_interrupts(&self) -> bool {
+        false
+    }
+
+    fn should_run_dma(&self) -> bool {
+        false
+    }
+}
+
+/// This is a compiled code of the following assembly code:
+/// ```asm
+/// ; jump to start, we have it at the end for forward declaration of `print_string`
+/// j start
+/// nop
+///
+/// print_string:
+///         ; epilogue
+///         addiu   $sp, $sp, -8
+///         sw      $ra, 4($sp)
+///         sw      $fp, 0($sp)
+///         move    $fp, $sp
+///
+///         ; print loop ($a0 is the string pointer, $a1 is the string length)
+/// loop:
+///         beqz    $a1, outside
+///         nop
+///         lbu     $v0, 0($a0)
+///         addiu   $a0, $a0, 1
+///         sub     $a1, $a1, 1
+///         sb      $v0, 4($zero)
+///         j       loop
+///         nop
+/// outside:
+///         ; epilogue
+///         move    $sp, $fp
+///         lw      $fp, 0($sp)
+///         lw      $ra, 4($sp)
+///         addiu   $sp, $sp, 8
+///         jr      $ra
+///         nop
+///
+/// start:
+///         ; setup the stack at 0xBFC0E000
+///         lui     $sp, 0xBFC0
+///         ori     $sp, $sp, 0xE000
+///
+///         ; setup the string pointer and length (0xBFC0D000, 14)
+///         lui     $a0, 0xBFC0
+///         ori     $a0, $a0, 0xD000
+///         addiu   $a1, $zer0, 14
+///
+///         ; call print_string
+///         jal     print_string
+///         nop
+///
+///         ; exit via register
+///         addiu   $v0, $zero, 1
+///         sb      $v0, 0($zero)
+///
+///         ; nothing should happen after this
+/// ```
+const CODE: [u8; 136] = [
+    0x17, 0x00, 0xf0, 0x0b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf8, 0xff, 0xbd, 0x27,
+    0x04, 0x00, 0xbf, 0xaf, 0x00, 0x00, 0xbe, 0xaf, 0x25, 0xf0, 0xa0, 0x03, 0x08, 0x00, 0xa0, 0x10,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x82, 0x90, 0x01, 0x00, 0x84, 0x24,
+    0xff, 0xff, 0xa5, 0x20, 0x04, 0x00, 0x02, 0xa0, 0x07, 0x00, 0xf0, 0x0b, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x25, 0xe8, 0xc0, 0x03, 0x00, 0x00, 0xbe, 0x8f, 0x04, 0x00, 0xbf, 0x8f,
+    0x08, 0x00, 0xbd, 0x27, 0x08, 0x00, 0xe0, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0xc0, 0xbf, 0x1d, 0x3c, 0x00, 0xe0, 0xbd, 0x37, 0xc0, 0xbf, 0x04, 0x3c, 0x00, 0xd0, 0x84, 0x34,
+    0x0e, 0x00, 0xa5, 0x24, 0x03, 0x00, 0xf0, 0x0f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x02, 0x24, 0x00, 0x00, 0x02, 0xa0,
+];
+
+const STRING_TO_PRINT: &[u8; 15] = b"Hello, world!\n\0";
+
+fn main() {
+    // collect logs
+    env_logger::init();
+
+    let mut cpu = Cpu::new();
+    let mut kseg1 = [0; 0x10000];
+    // copy the code
+    kseg1[0..CODE.len()].copy_from_slice(&CODE);
+    // copy the string to 0xBFC0D000
+    kseg1[0xD000..0xD000 + STRING_TO_PRINT.len()].copy_from_slice(STRING_TO_PRINT);
+
+    let mut bus = Bus {
+        kseg1,
+        is_done: false,
+    };
+
+    let mut total_cycles = 0;
+    while !bus.is_done {
+        let (n_cycles, _cpu_state) = cpu.clock(&mut bus, 1);
+        total_cycles += n_cycles;
+    }
+
+    println!("Total cycles: {}", total_cycles);
+}

--- a/trapezoid-core/src/cpu.rs
+++ b/trapezoid-core/src/cpu.rs
@@ -5,7 +5,7 @@ mod instructions_table;
 mod register;
 
 use crate::coprocessor::{Gte, SystemControlCoprocessor};
-use crate::memory::BusLine;
+pub use crate::memory::BusLine;
 
 pub use instruction::{Instruction, Opcode};
 pub use register::{RegisterType, Registers};
@@ -70,7 +70,15 @@ impl Debugger {
 
 const SHELL_LOCATION: u32 = 0x80030000;
 
-pub(crate) trait CpuBusProvider: BusLine {
+/// A specific Bus that is connected to the CPU directly, where it can send Interrupt messages
+/// to it and also request DMA access.
+///
+/// The trait only tells if the device is requesting for DMA,
+/// then the implementer should handle the DMA operation as needed.
+///
+/// It's done like that so that the CPU just need to know when it should be interrupted and allow
+/// the other components to run the DMA, here, the CPU doesn't run the DMA itself.
+pub trait CpuBusProvider: BusLine {
     fn pending_interrupts(&self) -> bool;
     fn should_run_dma(&self) -> bool;
 }
@@ -146,7 +154,7 @@ pub struct Cpu {
 }
 
 impl Cpu {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             // reset value
             regs: Registers::new(),

--- a/trapezoid-core/src/cpu.rs
+++ b/trapezoid-core/src/cpu.rs
@@ -11,6 +11,7 @@ pub use instruction::{Instruction, Opcode};
 pub use register::{RegisterType, Registers};
 
 #[cfg(feature = "debugger")]
+#[cfg_attr(docsrs, doc(cfg(feature = "debugger")))]
 pub use self::debugger::Debugger;
 
 #[cfg(not(feature = "debugger"))]
@@ -94,30 +95,36 @@ pub enum CpuState {
     Normal,
 
     #[cfg(feature = "debugger")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "debugger")))]
     /// Paused on an execution breakpoint, the pause happen BEFORE execution
     InstructionBreakpoint(u32),
 
     #[cfg(feature = "debugger")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "debugger")))]
     /// Paused on a write breakpoint, together with the value that was written
     /// the pause happen AFTER the operation
     WriteBreakpoint { addr: u32, bits: u8 },
 
     #[cfg(feature = "debugger")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "debugger")))]
     /// Paused on a read breakpoint
     /// the pause happen AFTER the operation
     ReadBreakpoint { addr: u32, bits: u8 },
 
     #[cfg(feature = "debugger")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "debugger")))]
     /// Paused after a single instruction was executed
     Step,
 
     #[cfg(feature = "debugger")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "debugger")))]
     /// Paused after a single instruction was executed, if the instruction is `Jal` or `Jalr`
     /// which is used for function calls, the pause will happen after the function returns,
     /// i.e. step over the function
     StepOver,
 
     #[cfg(feature = "debugger")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "debugger")))]
     /// Continue execution until the CPU exit the current function
     StepOut,
 }
@@ -173,6 +180,7 @@ impl Cpu {
     }
 
     #[cfg(feature = "debugger")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "debugger")))]
     pub fn debugger(&mut self) -> &mut Debugger {
         &mut self.debugger
     }

--- a/trapezoid-core/src/cpu/instruction.rs
+++ b/trapezoid-core/src/cpu/instruction.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use super::instructions_table::{PRIMARY_OPCODES, SECONDARY_OPCODES};
 use super::RegisterType;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Opcode {
     #[doc(hidden)]
     /// This is a special opcode used when parsing the instruction,

--- a/trapezoid-core/src/lib.rs
+++ b/trapezoid-core/src/lib.rs
@@ -128,7 +128,8 @@ impl Psx {
             let cpu_cycles;
             let shell_reached;
 
-            (shell_reached, cpu_cycles, cpu_state) = self.cpu.clock(&mut self.bus, 56);
+            (cpu_cycles, cpu_state) = self.cpu.clock(&mut self.bus, 56);
+            shell_reached = self.cpu.is_shell_reached();
 
             // handle fast booting and hijacking the bios to load exe
             if shell_reached && (self.config.fast_boot || self.exe_file.is_some()) {

--- a/trapezoid-core/src/lib.rs
+++ b/trapezoid-core/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 mod cdrom;
 mod controller_mem_card;
 mod coprocessor;

--- a/trapezoid-core/src/memory.rs
+++ b/trapezoid-core/src/memory.rs
@@ -29,6 +29,10 @@ use ram::{MainRam, Scratchpad};
 
 pub type Result<T, E = String> = std::result::Result<T, E>;
 
+/// A notion of a Busline, which is an interface to interact with memory mapped devices
+/// it can be a memory, or other stuff.
+///
+/// Here we implement the behavior for `read/write` for each size of data (u32, u16, u8).
 pub trait BusLine {
     fn read_u32(&mut self, addr: u32) -> Result<u32> {
         Err(format!(


### PR DESCRIPTION
Improving documentations for `trapezoid-core`
- Add `debugger` feature tag showing which items are under it.
- Improved the API and exposed a lot of different things for it including:
   - creating `Cpu` instance.
   - `BusLine` and `CpuBusProvider` for creating custom memory for `Cpu`.
- Added `example` `trapezoid_cpu` on how to use these new APIs to create and interact with the `Cpu`.

> Note: Currently, there is an issue with the latest nightly and thus it crashes in `docs.rs` https://github.com/rust-lang/rust/issues/137662, Will wait until its fixed.